### PR TITLE
Function for pretty saving the `config.yml`

### DIFF
--- a/src/sinol_make/commands/run/__init__.py
+++ b/src/sinol_make/commands/run/__init__.py
@@ -521,8 +521,7 @@ class Command(BaseCommand):
 
 
 				self.config["sinol_expected_scores"] = expected_scores
-				with open(os.path.join(os.getcwd(), "config.yml"), "w") as f:
-					yaml.dump(self.config, f, default_flow_style=None)
+				util.save_config(self.config)
 				print(util.info("Saved suggested expected scores description."))
 			else:
 				util.exit_with_error("Use flag --apply_suggestions to apply suggestions.")

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -139,7 +139,8 @@ def save_config(config):
 					del config[field] # Same reason for deleting as above
 
 		if config != {}:
-			yaml.dump(config, config_file) # Save any custom fields
+			# All remaining non-considered fields are appended to the end of the file
+			yaml.dump(config, config_file)
 
 
 def color_red(text): return "\033[91m{}\033[00m".format(text)

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -113,6 +113,8 @@ def save_config(config):
 	Function to save nicely formated config.yml
 	"""
 
+	# The order of the fields in the config.yml file for the sake of readability
+	# The fields that are not in this list will be appended to the end of the file
 	order = [
 		"title",
 		"memory_limit",
@@ -128,12 +130,12 @@ def save_config(config):
 	config = config.copy()
 	with open("config.yml", "w") as config_file:
 		for field in order:
-			if isinstance(field, dict):
+			if isinstance(field, dict): # If the field is a dict, it means that it has a custom property (for example default_flow_style)
 				if field["key"] in config:
 					yaml.dump({field["key"]: config[field["key"]]}, config_file, default_flow_style=field["default_flow_style"])
 					# The considered fields are deleted, thus `config` at then end will contain only custom fields written by the user
 					del config[field["key"]]
-			else:
+			else: # If the field is a string, it means that it doesn't have any custom properties, it's just a dict key
 				if field in config:
 					yaml.dump({field: config[field]}, config_file)
 					del config[field] # Same reason for deleting as above

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -131,7 +131,8 @@ def save_config(config):
 			if isinstance(field, dict):
 				if field["key"] in config:
 					yaml.dump({field["key"]: config[field["key"]]}, config_file, default_flow_style=field["default_flow_style"])
-					del config[field["key"]] # Fields are deleted so that if there were any custom fields, they will be saved at the end of the file
+					# The considered fields are deleted, thus `config` at then end will contain only custom fields written by the user
+					del config[field["key"]]
 			else:
 				if field in config:
 					yaml.dump({field: config[field]}, config_file)

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -1,4 +1,4 @@
-import glob, importlib, os, sys, subprocess, requests, tarfile
+import glob, importlib, os, sys, subprocess, requests, tarfile, yaml
 
 def get_commands():
 	"""
@@ -106,6 +106,38 @@ def get_oiejq_path():
 		return os.path.expanduser('~/.local/bin/oiejq')
 	else:
 		return None
+
+
+def save_config(config):
+	"""
+	Function to save nicely formated config.yml
+	"""
+
+	order = [
+		"title",
+		"memory_limit",
+		"time_limit",
+		"override_limits",
+		"scores",
+		{
+			"key": "sinol_expected_scores",
+			"default_flow_style": None
+		}
+	]
+	config_file = open("config.yml", "w")
+
+	for field in order:
+		if isinstance(field, dict):
+			if field["key"] in config:
+				yaml.dump({field["key"]: config[field["key"]]}, config_file, default_flow_style=field["default_flow_style"])
+				del config[field["key"]]
+		else:
+			if field in config:
+				yaml.dump({field: config[field]}, config_file)
+				del config[field]
+
+	yaml.dump(config, config_file)
+	config_file.close()
 
 
 def color_red(text): return "\033[91m{}\033[00m".format(text)

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -146,6 +146,7 @@ def save_config(config):
 					del config[field] # Same reason for deleting as above.
 
 		if config != {}:
+			print(warning("Found unknown fields in config.yml: " + ", ".join([str(x) for x in config])))
 			# All remaining non-considered fields are appended to the end of the file.
 			yaml.dump(config, config_file)
 

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -124,20 +124,21 @@ def save_config(config):
 			"default_flow_style": None
 		}
 	]
-	config_file = open("config.yml", "w")
 
-	for field in order:
-		if isinstance(field, dict):
-			if field["key"] in config:
-				yaml.dump({field["key"]: config[field["key"]]}, config_file, default_flow_style=field["default_flow_style"])
-				del config[field["key"]]
-		else:
-			if field in config:
-				yaml.dump({field: config[field]}, config_file)
-				del config[field]
+	config = config.copy()
+	with open("config.yml", "w") as config_file:
+		for field in order:
+			if isinstance(field, dict):
+				if field["key"] in config:
+					yaml.dump({field["key"]: config[field["key"]]}, config_file, default_flow_style=field["default_flow_style"])
+					del config[field["key"]]
+			else:
+				if field in config:
+					yaml.dump({field: config[field]}, config_file)
+					del config[field]
 
-	yaml.dump(config, config_file)
-	config_file.close()
+		if config != {}:
+			yaml.dump(config, config_file)
 
 
 def color_red(text): return "\033[91m{}\033[00m".format(text)

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -113,7 +113,7 @@ def save_config(config):
 	Function to save nicely formated config.yml
 	"""
 
-	# The order of the fields in the config.yml file for the sake of readability
+	# We add the fields in the config.yml in a particular order to make the config more readable
 	# The fields that are not in this list will be appended to the end of the file
 	order = [
 		"title",
@@ -133,9 +133,9 @@ def save_config(config):
 			if isinstance(field, dict): # If the field is a dict, it means that it has a custom property (for example default_flow_style)
 				if field["key"] in config:
 					yaml.dump({field["key"]: config[field["key"]]}, config_file, default_flow_style=field["default_flow_style"])
-					# The considered fields are deleted, thus `config` at then end will contain only custom fields written by the user
+					# The considered fields are deleted, thus `config` at the end will contain only custom fields written by the user
 					del config[field["key"]]
-			else: # If the field is a string, it means that it doesn't have any custom properties, it's just a dict key
+			else: # When the field is a string, it doesn't have any custom properties, so it's just a dict key
 				if field in config:
 					yaml.dump({field: config[field]}, config_file)
 					del config[field] # Same reason for deleting as above

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -110,11 +110,11 @@ def get_oiejq_path():
 
 def save_config(config):
 	"""
-	Function to save nicely formated config.yml
+	Function to save nicely formated config.yml.
 	"""
 
-	# We add the fields in the config.yml in a particular order to make the config more readable
-	# The fields that are not in this list will be appended to the end of the file
+	# We add the fields in the `config.yml`` in a particular order to make the config more readable.
+	# The fields that are not in this list will be appended to the end of the file.
 	order = [
 		"title",
 		"memory_limit",
@@ -130,18 +130,18 @@ def save_config(config):
 	config = config.copy()
 	with open("config.yml", "w") as config_file:
 		for field in order:
-			if isinstance(field, dict): # If the field is a dict, it means that it has a custom property (for example default_flow_style)
+			if isinstance(field, dict): # If the field is a dict, it means that it has a custom property (for example default_flow_style).
 				if field["key"] in config:
 					yaml.dump({field["key"]: config[field["key"]]}, config_file, default_flow_style=field["default_flow_style"])
-					# The considered fields are deleted, thus `config` at the end will contain only custom fields written by the user
+					# The considered fields are deleted, thus `config` at the end will contain only custom fields written by the user.
 					del config[field["key"]]
-			else: # When the field is a string, it doesn't have any custom properties, so it's just a dict key
+			else: # When the field is a string, it doesn't have any custom properties, so it's just a dict key.
 				if field in config:
 					yaml.dump({field: config[field]}, config_file)
-					del config[field] # Same reason for deleting as above
+					del config[field] # Same reason for deleting as above.
 
 		if config != {}:
-			# All remaining non-considered fields are appended to the end of the file
+			# All remaining non-considered fields are appended to the end of the file.
 			yaml.dump(config, config_file)
 
 

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -131,14 +131,14 @@ def save_config(config):
 			if isinstance(field, dict):
 				if field["key"] in config:
 					yaml.dump({field["key"]: config[field["key"]]}, config_file, default_flow_style=field["default_flow_style"])
-					del config[field["key"]]
+					del config[field["key"]] # Fields are deleted so that if there were any custom fields, they will be saved at the end of the file
 			else:
 				if field in config:
 					yaml.dump({field: config[field]}, config_file)
-					del config[field]
+					del config[field] # Same reason for deleting as above
 
 		if config != {}:
-			yaml.dump(config, config_file)
+			yaml.dump(config, config_file) # Save any custom fields
 
 
 def color_red(text): return "\033[91m{}\033[00m".format(text)

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -117,10 +117,15 @@ def save_config(config):
 	# The fields that are not in this list will be appended to the end of the file.
 	order = [
 		"title",
+		"title_pl",
+		"title_en",
 		"memory_limit",
+		"memory_limits",
 		"time_limit",
+		"time_limits",
 		"override_limits",
 		"scores",
+		"extra_compilation_files",
 		{
 			"key": "sinol_expected_scores",
 			"default_flow_style": None


### PR DESCRIPTION
I couldn't find an easier and cleaner way of doing this. One of the advantages is that we have full control over what order and how the `config.yml` is saved.