### PR TITLE
Allow only `gcc` in versions 9 and 10 on MacOS

### DIFF
--- a/src/sinol_make/commands/run/__init__.py
+++ b/src/sinol_make/commands/run/__init__.py
@@ -41,9 +41,9 @@ class Command(BaseCommand):
 		parser.add_argument('--oiejq_path', type=str,
 		      				help='path to oiejq executable (default: `~/.local/bin/oiejq`)')
 		parser.add_argument('--c_compiler_path', type=str, default=compiler.get_c_compiler_path(),
-		    				help='C compiler to use (default for Linux and Windows: gcc, default for Mac: gcc-{9-12})')
+		    				help='C compiler to use (default for Linux and Windows: gcc, default for Mac: gcc-{9,10})')
 		parser.add_argument('--cpp_compiler_path', type=str, default=compiler.get_cpp_compiler_path(),
-		    				help='C++ compiler to use (default for Linux and Windows: g++, default for Mac: gcc-{9-12})')
+		    				help='C++ compiler to use (default for Linux and Windows: g++, default for Mac: g++-{9,10})')
 		parser.add_argument('--python_interpreter_path', type=str, default=compiler.get_python_interpreter_path(),
 		    				help='Python interpreter to use (default: python3)')
 		parser.add_argument('--java_compiler_path', type=str, default=compiler.get_java_compiler_path(),
@@ -586,14 +586,14 @@ class Command(BaseCommand):
 				compiler = 'C compiler'
 				flag = '--c_compiler_path'
 				if sys.platform == 'darwin':
-					tried = 'gcc-{9,10,11,12,13}'
+					tried = 'gcc-{9,10}'
 				else:
 					tried = 'gcc'
 			elif ext == '.cpp' and args.cpp_compiler_path is None:
 				compiler = 'C++ compiler'
 				flag = '--cpp_compiler_path'
 				if sys.platform == 'darwin':
-					tried = 'g++-{9,10,11,12,13}'
+					tried = 'g++-{9,10}'
 				else:
 					tried = 'g++'
 			elif ext == '.py' and args.python_interpreter_path is None:

--- a/src/sinol_make/commands/run/__init__.py
+++ b/src/sinol_make/commands/run/__init__.py
@@ -586,14 +586,14 @@ class Command(BaseCommand):
 				compiler = 'C compiler'
 				flag = '--c_compiler_path'
 				if sys.platform == 'darwin':
-					tried = 'gcc-{9,10,11,12}'
+					tried = 'gcc-{9,10,11,12,13}'
 				else:
 					tried = 'gcc'
 			elif ext == '.cpp' and args.cpp_compiler_path is None:
 				compiler = 'C++ compiler'
 				flag = '--cpp_compiler_path'
 				if sys.platform == 'darwin':
-					tried = 'g++-{9,10,11,12}'
+					tried = 'g++-{9,10,11,12,13}'
 				else:
 					tried = 'g++'
 			elif ext == '.py' and args.python_interpreter_path is None:

--- a/src/sinol_make/commands/run/__init__.py
+++ b/src/sinol_make/commands/run/__init__.py
@@ -41,9 +41,9 @@ class Command(BaseCommand):
 		parser.add_argument('--oiejq_path', type=str,
 		      				help='path to oiejq executable (default: `~/.local/bin/oiejq`)')
 		parser.add_argument('--c_compiler_path', type=str, default=compiler.get_c_compiler_path(),
-		    				help='C compiler to use (default for Linux and Windows: gcc, default for Mac: gcc-{9,10})')
+		    				help='C compiler to use (default for Linux and Windows: gcc, default for Mac: gcc-9 or gcc-10)')
 		parser.add_argument('--cpp_compiler_path', type=str, default=compiler.get_cpp_compiler_path(),
-		    				help='C++ compiler to use (default for Linux and Windows: g++, default for Mac: g++-{9,10})')
+		    				help='C++ compiler to use (default for Linux and Windows: g++, default for Mac: g++-9 or g++-10)')
 		parser.add_argument('--python_interpreter_path', type=str, default=compiler.get_python_interpreter_path(),
 		    				help='Python interpreter to use (default: python3)')
 		parser.add_argument('--java_compiler_path', type=str, default=compiler.get_java_compiler_path(),

--- a/src/sinol_make/helpers/compiler.py
+++ b/src/sinol_make/helpers/compiler.py
@@ -25,7 +25,7 @@ def get_c_compiler_path():
 		else:
 			return 'gcc'
 	elif sys.platform == 'darwin':
-		for i in range(9, 14):
+		for i in range(9, 11):
 			compiler = 'gcc-' + str(i)
 			if check_if_installed(compiler):
 				return compiler
@@ -43,7 +43,7 @@ def get_cpp_compiler_path():
 		else:
 			return 'g++'
 	elif sys.platform == 'darwin':
-		for i in range(9, 14):
+		for i in range(9, 11):
 			compiler = 'g++-' + str(i)
 			if check_if_installed(compiler):
 				return compiler

--- a/src/sinol_make/helpers/compiler.py
+++ b/src/sinol_make/helpers/compiler.py
@@ -25,7 +25,7 @@ def get_c_compiler_path():
 		else:
 			return 'gcc'
 	elif sys.platform == 'darwin':
-		for i in range(9, 13):
+		for i in range(9, 14):
 			compiler = 'gcc-' + str(i)
 			if check_if_installed(compiler):
 				return compiler
@@ -43,7 +43,7 @@ def get_cpp_compiler_path():
 		else:
 			return 'g++'
 	elif sys.platform == 'darwin':
-		for i in range(9, 13):
+		for i in range(9, 14):
 			compiler = 'g++-' + str(i)
 			if check_if_installed(compiler):
 				return compiler

--- a/src/sinol_make/helpers/compiler.py
+++ b/src/sinol_make/helpers/compiler.py
@@ -43,7 +43,7 @@ def get_cpp_compiler_path():
 		else:
 			return 'g++'
 	elif sys.platform == 'darwin':
-		for i in range(9, 11):
+		for i in [9, 10]:
 			compiler = 'g++-' + str(i)
 			if check_if_installed(compiler):
 				return compiler

--- a/src/sinol_make/helpers/compiler.py
+++ b/src/sinol_make/helpers/compiler.py
@@ -25,7 +25,7 @@ def get_c_compiler_path():
 		else:
 			return 'gcc'
 	elif sys.platform == 'darwin':
-		for i in range(9, 11):
+		for i in [9, 10]:
 			compiler = 'gcc-' + str(i)
 			if check_if_installed(compiler):
 				return compiler


### PR DESCRIPTION
MacOS has new version of g++ and gcc compilers. Now the tool will check for their existence, but I wonder if there is a better way of doing this.