### PR TITLE
Split points evenly when `scores` not defined in `config.yml`

### DIFF
--- a/tests/commands/run/test_integration.py
+++ b/tests/commands/run/test_integration.py
@@ -163,3 +163,26 @@ def test_weak_compilation_flags(create_package):
     args = parser.parse_args(["run", "--weak_compilation_flags", "--time_tool", "time"])
     command = Command()
     command.run(args)
+
+
+@pytest.mark.parametrize("create_package", [get_simple_package_path()], indirect=True)
+def test_no_scores(capsys, create_package, time_tool):
+    """
+    Test with no scores key in config.yml.
+    """
+    package_path = create_package
+    command = get_command()
+    create_ins_outs(package_path, command)
+
+    config_path = os.path.join(package_path, "config.yml")
+    config = yaml.load(open(config_path, "r"), Loader=yaml.SafeLoader)
+    del config["scores"]
+    open(config_path, "w").write(yaml.dump(config))
+
+    parser = configure_parsers()
+    args = parser.parse_args(["run", "--time_tool", time_tool])
+    command = Command()
+    command.run(args)
+
+    out = capsys.readouterr().out
+    assert "Scores are not defined in config.yml. Points will be assigned equally to all groups." in out

--- a/tests/commands/run/test_unit.py
+++ b/tests/commands/run/test_unit.py
@@ -94,6 +94,7 @@ def test_execution(create_package, time_tool):
 def test_calculate_points():
     os.chdir(get_simple_package_path())
     command = get_command()
+    command.scores = command.config["scores"]
 
     assert command.calculate_points({1: "OK", 2: "OK", 3: "OK", 4: "OK"}) == 100
     assert command.calculate_points({1: "OK", 2: "OK", 3: "OK", 4: "WA"}) == 75
@@ -427,4 +428,26 @@ def test_print_expected_scores_diff(capsys, create_package):
             "expected": {1: "OK", 2: "OK", 3: "OK", 5: "OK"},
             "points": 75
         }
+    }
+
+
+@pytest.mark.parametrize("create_package", [get_simple_package_path()], indirect=["create_package"])
+def test_set_scores(create_package):
+    """
+    Test set_scores function.
+    """
+    package_path = create_package
+    command = get_command(package_path)
+    command.args = argparse.Namespace(tests=["in/abc0a.in", "in/abc1a.in", "in/abc2a.in", "in/abc3a.in", "in/abc4a.in",
+                                             "in/abc5a.in", "in/abc6a.in"])
+    del command.config["scores"]
+    command.set_scores()
+    assert command.scores == {
+        0: 0,
+        1: 16,
+        2: 16,
+        3: 16,
+        4: 16,
+        5: 16,
+        6: 20
     }


### PR DESCRIPTION
Closes #44 