### PR TITLE
Add autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,10 @@ other tools for measuring time (which are non-deterministic and produce reports 
 - Windows (WSL): `apt install time timeout`
 - macOS: `brew install gnu-time coreutils`
 
-If you would like to have autocomplete for `sinol-make` commands,
-add the following line to your `~/.bashrc` (or `~/.zshrc`) file:
+### Autocompletion (optional)
 
-```shell
-eval "$(register-python-argcomplete sinol-make)"
-```
-or run the following command:
+If you would like to have autocompletion for `sinol-make` commands,
+run the following command and refresh the shell (e.g. by opening a new terminal):
 
 ```shell
 activate-global-python-argcomplete

--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ other tools for measuring time (which are non-deterministic and produce reports 
 - Windows (WSL): `apt install time timeout`
 - macOS: `brew install gnu-time coreutils`
 
+If you would like to have autocomplete for `sinol-make` commands,
+add the following line to your `~/.bashrc` (or `~/.zshrc`) file:
+
+```shell
+eval "$(register-python-argcomplete sinol-make)"
+```
+or run the following command:
+
+```shell
+activate-global-python-argcomplete
+```
+
 ### Usage
 
 The availabe commands (see `sinol-make --help`) are:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ build-backend = "setuptools.build_meta"
 name = "sinol-make"
 dynamic = ["version"]
 authors = [
-  { name="Mateusz Masiarz", email="m.masiarz@fri.edu.pl" }
+    { name="Mateusz Masiarz", email="m.masiarz@fri.edu.pl" }
 ]
 maintainers = [
-  { name="Tomasz Nowak", email="tomasz.nowak@tonowak.com" }
+    { name="Tomasz Nowak", email="tomasz.nowak@tonowak.com" }
 ]
 description = "CLI tool for creating sio2 task packages"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,11 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-	"argparse",
+    "argparse",
     "argcomplete",
-	"requests",
-	"PyYAML",
-	"dictdiffer"
+    "requests",
+    "PyYAML",
+    "dictdiffer"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 ]
 dependencies = [
 	"argparse",
+    "argcomplete",
 	"requests",
 	"PyYAML",
 	"dictdiffer"
@@ -28,9 +29,9 @@ dependencies = [
 
 [project.optional-dependencies]
 tests = [
-  "pytest",
-  "pytest-cov",
-  "requests-mock",
+    "pytest",
+    "pytest-cov",
+    "requests-mock",
 ]
 
 [project.urls]

--- a/src/sinol_make/__init__.py
+++ b/src/sinol_make/__init__.py
@@ -1,3 +1,6 @@
+# PYTHON_ARCOMPLETE_OK
+
+import argcomplete
 import argparse
 import sys
 
@@ -22,13 +25,15 @@ def configure_parsers():
 
     for command in commands:
         command.configure_subparser(subparsers)
+
+    argcomplete.autocomplete(parser)
     return parser
 
 
 def main():
     parser = configure_parsers()
-    commands = util.get_commands()
     args = parser.parse_args()
+    commands = util.get_commands()
 
     for command in commands:
         if command.get_name() == args.command:


### PR DESCRIPTION
I found a package for autocompletion, but I'd like you to test it. For me the completion works in about a second, so it feels kinda slow. 

After installing sinol-make you can enable it either by adding `eval "$(register-python-argcomplete sinol-make)"` to your `.bashrc` (or `.zshrc`) or using `activate-global-python-argcomplete` and restarting shell.