### PR TITLE
Fixes for python 3.7 and 3.8

### DIFF
--- a/.github/workflows/Arch.yaml
+++ b/.github/workflows/Arch.yaml
@@ -4,6 +4,10 @@ on: [push]
 jobs:
   pytest:
     runs-on: self-hosted
+    strategy:
+        matrix:
+            python-version: [3.7, 3.11]
+    name: pytest-arch-python-${{ matrix.python-version }}
     container:
       image: archlinux:latest
       volumes:
@@ -17,10 +21,10 @@ jobs:
         run: |
           sysctl kernel.perf_event_paranoid=-1
           pacman -Syu --noconfirm diffutils time gcc
-      - name: Set up Python 3.11
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           pip3 install .[tests]

--- a/.github/workflows/Arch.yaml
+++ b/.github/workflows/Arch.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: self-hosted
     strategy:
         matrix:
-            python-version: [3.7, 3.11.4]
+            python-version: ["3.7", "3.11.4"]
     name: pytest-arch-python-${{ matrix.python-version }}
     container:
       image: archlinux:latest

--- a/.github/workflows/Arch.yaml
+++ b/.github/workflows/Arch.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: self-hosted
     strategy:
         matrix:
-            python-version: [3.7, 3.11]
+            python-version: [3.7, 3.11.4]
     name: pytest-arch-python-${{ matrix.python-version }}
     container:
       image: archlinux:latest
@@ -22,7 +22,7 @@ jobs:
           sysctl kernel.perf_event_paranoid=-1
           pacman -Syu --noconfirm diffutils time gcc
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/Arch.yaml
+++ b/.github/workflows/Arch.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: self-hosted
     strategy:
         matrix:
-            python-version: ["3.7", "3.11.4"]
+            python-version: ["3.7.17", "3.11.4"]
     name: pytest-arch-python-${{ matrix.python-version }}
     container:
       image: archlinux:latest

--- a/.github/workflows/GithubRunner.yaml
+++ b/.github/workflows/GithubRunner.yaml
@@ -3,14 +3,18 @@ run-name: Run tests for GitHub Runner
 on: [push]
 jobs:
   pytest:
+    strategy:
+        matrix:
+            python-version: [3.7, 3.11]
+    name: pytest-github-runner-python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Python 3.11
+      - name: Install Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           pip install .[tests]

--- a/.github/workflows/GithubRunner.yaml
+++ b/.github/workflows/GithubRunner.yaml
@@ -5,7 +5,7 @@ jobs:
   pytest:
     strategy:
         matrix:
-            python-version: ["3.7", "3.11"]
+            python-version: ["3.7.17", "3.11.4"]
     name: pytest-github-runner-python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/GithubRunner.yaml
+++ b/.github/workflows/GithubRunner.yaml
@@ -5,7 +5,7 @@ jobs:
   pytest:
     strategy:
         matrix:
-            python-version: [3.7, 3.11]
+            python-version: ["3.7", "3.11"]
     name: pytest-github-runner-python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/Ubuntu.yaml
+++ b/.github/workflows/Ubuntu.yaml
@@ -21,14 +21,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Prepare system
         run: |
-          apt update
-          export TZ=Europe/Warsaw
-          ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
           sysctl kernel.perf_event_paranoid=-1
       - name: Set up Python ${{ matrix.python-version }}
-        run: |
-          apt install -y python${{ matrix.python-version }} python${{ matrix.python-version }}-dev python3-pip
-          pip3 install -U setuptools
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           pip3 install .[tests]

--- a/.github/workflows/Ubuntu.yaml
+++ b/.github/workflows/Ubuntu.yaml
@@ -4,6 +4,10 @@ on: [push]
 jobs:
   pytest:
     runs-on: self-hosted
+    strategy:
+        matrix:
+            python-version: [3.7, 3.11]
+    name: pytest-ubuntu-python-${{ matrix.python-version }}
     container:
       image: ubuntu:latest
       volumes:
@@ -21,9 +25,9 @@ jobs:
           export TZ=Europe/Warsaw
           ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
           sysctl kernel.perf_event_paranoid=-1
-      - name: Set up Python 3.11
+      - name: Set up Python ${{ matrix.python-version }}
         run: |
-          apt install -y python3.11 python3.11-dev python3-pip
+          apt install -y python${{ matrix.python-version }} python${{ matrix.python-version }}-dev python3-pip
           pip3 install -U setuptools
       - name: Install dependencies
         run: |

--- a/.github/workflows/Ubuntu.yaml
+++ b/.github/workflows/Ubuntu.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: self-hosted
     strategy:
         matrix:
-            python-version: ["3.7", "3.11"]
+            python-version: ["3.7.17", "3.11.4"]
     name: pytest-ubuntu-python-${{ matrix.python-version }}
     container:
       image: ubuntu:latest

--- a/.github/workflows/Ubuntu.yaml
+++ b/.github/workflows/Ubuntu.yaml
@@ -22,6 +22,7 @@ jobs:
       - name: Prepare system
         run: |
           apt update
+          apt install -y sqlite3 sqlite3-doc
           sysctl kernel.perf_event_paranoid=-1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/Ubuntu.yaml
+++ b/.github/workflows/Ubuntu.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Prepare system
         run: |
+          apt update
           sysctl kernel.perf_event_paranoid=-1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/Ubuntu.yaml
+++ b/.github/workflows/Ubuntu.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: self-hosted
     strategy:
         matrix:
-            python-version: [3.7, 3.11]
+            python-version: ["3.7", "3.11"]
     name: pytest-ubuntu-python-${{ matrix.python-version }}
     container:
       image: ubuntu:latest

--- a/.github/workflows/Ubuntu.yaml
+++ b/.github/workflows/Ubuntu.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Prepare system
         run: |
           apt update
-          apt install -y sqlite3 sqlite3-doc
+          apt install -y sqlite3 sqlite3-doc build-essential
           sysctl kernel.perf_event_paranoid=-1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/macOS.yaml
+++ b/.github/workflows/macOS.yaml
@@ -5,13 +5,17 @@ on: [push]
 jobs:
   pytest:
     runs-on: macos-latest
+    strategy:
+        matrix:
+            python-version: [3.7, 3.11]
+    name: pytest-macos-python-${{ matrix.python-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Python 3.11
+      - name: Install Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: ${{ matrix.python-version }}
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install Python dependencies

--- a/.github/workflows/macOS.yaml
+++ b/.github/workflows/macOS.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Homebrew

--- a/.github/workflows/macOS.yaml
+++ b/.github/workflows/macOS.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     strategy:
         matrix:
-            python-version: [3.7, 3.11]
+            python-version: ["3.7", "3.11"]
     name: pytest-macos-python-${{ matrix.python-version }}
     steps:
       - name: Checkout

--- a/.github/workflows/macOS.yaml
+++ b/.github/workflows/macOS.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-latest
     strategy:
         matrix:
-            python-version: ["3.7", "3.11"]
+            python-version: ["3.7.17", "3.11.4"]
     name: pytest-macos-python-${{ matrix.python-version }}
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "argcomplete",
     "requests",
     "PyYAML",
-    "dictdiffer"
+    "dictdiffer",
+    "importlib-resources",
 ]
 
 [project.optional-dependencies]

--- a/src/sinol_make/commands/inwer/__init__.py
+++ b/src/sinol_make/commands/inwer/__init__.py
@@ -5,6 +5,7 @@ import threading
 import argparse
 import os
 import multiprocessing as mp
+from typing import Dict, List
 
 from sinol_make import util
 from sinol_make.commands.inwer.structs import TestResult, InwerExecution, VerificationResult, TableData
@@ -77,10 +78,14 @@ class Command(BaseCommand):
             out.decode('utf-8')
         )
 
-    def verify_and_print_table(self) -> dict[str, TestResult]:
+    def verify_and_print_table(self) -> Dict[str, TestResult]:
+        """
+        Verifies all tests and prints the results in a table.
+        :return: dictionary of TestResult objects
+        """
         results = {}
         sorted_tests = sorted(self.tests, key=lambda x: x[0])
-        executions: list[InwerExecution] = []
+        executions: List[InwerExecution] = []
         for test in sorted_tests:
             results[test] = TestResult(test)
             executions.append(InwerExecution(test, results[test].test_name, self.inwer_executable))
@@ -137,7 +142,7 @@ class Command(BaseCommand):
             print('Verifying tests: ' + util.bold(', '.join(self.tests)))
 
         self.compile_inwer(args)
-        results: dict[str, TestResult] = self.verify_and_print_table()
+        results: Dict[str, TestResult] = self.verify_and_print_table()
         print('')
 
         failed_tests = []

--- a/src/sinol_make/commands/inwer/inwer_util.py
+++ b/src/sinol_make/commands/inwer/inwer_util.py
@@ -2,6 +2,8 @@ import glob
 import os
 import sys
 from io import StringIO
+from typing import Union
+
 import argparse
 
 from sinol_make import util
@@ -11,7 +13,7 @@ from sinol_make.helpers import compiler
 from sinol_make.interfaces.Errors import CompilationError
 
 
-def get_inwer_path(task_id: str, path = None) -> str or None:
+def get_inwer_path(task_id: str, path = None) -> Union[str, None]:
     """
     Returns path to inwer executable for given task or None if no inwer was found.
     """

--- a/src/sinol_make/commands/inwer/structs.py
+++ b/src/sinol_make/commands/inwer/structs.py
@@ -1,5 +1,6 @@
 import os
 from dataclasses import dataclass
+from typing import Dict
 
 from sinol_make.helpers import package_util
 
@@ -34,7 +35,7 @@ class TableData:
     """
 
     # Dictionary with test path as key and verification result as value.
-    results: dict[str, TestResult]
+    results: Dict[str, TestResult]
 
     # Number of executions finished
     i: int

--- a/src/sinol_make/commands/run/__init__.py
+++ b/src/sinol_make/commands/run/__init__.py
@@ -6,6 +6,7 @@ import signal
 import threading
 from io import StringIO
 import glob
+from typing import Dict
 
 from sinol_make.commands.run.structs import ExecutionResult, ResultChange, ValidationResult, ExecutionData, \
     PointsChange, PrintData
@@ -988,7 +989,12 @@ class Command(BaseCommand):
         else:
             print(util.warning('There are no tests to run.'))
 
-    def check_errors(self, results: dict[str, dict[str, dict[str, ExecutionResult]]]):
+    def check_errors(self, results: Dict[str, Dict[str, Dict[str, ExecutionResult]]]):
+        """
+        Checks if there were any errors during execution and exits if there were.
+        :param results: Dictionary of results.
+        :return:
+        """
         error_msg = ""
         for solution in results:
             for group in results[solution]:

--- a/src/sinol_make/commands/run/structs.py
+++ b/src/sinol_make/commands/run/structs.py
@@ -63,8 +63,6 @@ class ExecutionData:
     memory_limit: int
     # Path to the timetool executable
     timetool_path: str
-    # Dictionary of pids for each execution
-    execution_pids: dict[dict[str, int]]
 
 
 @dataclass

--- a/src/sinol_make/helpers/compile.py
+++ b/src/sinol_make/helpers/compile.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Union
 import os
 import sys
 import shutil
@@ -79,7 +79,8 @@ def compile(program, output, compilers: Compilers = None, compile_log = None, we
         return True
 
 
-def compile_file(file_path: str, name: str, compilers: Compilers, weak_compilation_flags = False) -> Tuple[str or None, str]:
+def compile_file(file_path: str, name: str, compilers: Compilers, weak_compilation_flags = False) \
+        -> Tuple[Union[str, None], str]:
     """
     Compile a file
     :param file_path: Path to the file to compile

--- a/src/sinol_make/helpers/compiler.py
+++ b/src/sinol_make/helpers/compiler.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import argparse
 import os
 
@@ -92,7 +94,13 @@ def get_default_compilers():
     )
 
 
-def verify_compilers(args: argparse.Namespace, solutions: list[str]) -> Compilers:
+def verify_compilers(args: argparse.Namespace, solutions: List[str]) -> Compilers:
+    """
+    Verify that specified compilers exist.
+    :param args: argparse.Namespace arguments
+    :param solutions: List of solutions (used for checking if a compiler is specified)
+    :return: Compilers object with all the compilers
+    """
     for solution in solutions:
         ext = os.path.splitext(solution)[1]
         compiler = ""

--- a/src/sinol_make/helpers/package_util.py
+++ b/src/sinol_make/helpers/package_util.py
@@ -1,4 +1,5 @@
 import os
+from typing import List, Union
 
 
 def get_task_id() -> str:
@@ -23,7 +24,12 @@ def get_test_key(test):
     return get_group(test), test
 
 
-def get_tests(arg_tests: list[str] or None) -> list[str]:
+def get_tests(arg_tests: Union[List[str], None]) -> List[str]:
+    """
+    Returns list of tests to run.
+    :param arg_tests: Tests specified in command line arguments. If None, all tests are returned.
+    :return: List of tests to run.
+    """
     if arg_tests is None:
         all_tests = ["in/%s" % test for test in os.listdir("in/")
                      if test[-3:] == ".in"]

--- a/src/sinol_make/helpers/printer.py
+++ b/src/sinol_make/helpers/printer.py
@@ -34,7 +34,7 @@ def printer_thread(run_event, func, *args, **kwargs):
     wrapper(_printer, run_event, func, *args, **kwargs)
 
 
-def _printer(stdscr: curses.window, run_event, func, *args, **kwargs):
+def _printer(stdscr, run_event, func, *args, **kwargs):
     """
     Function called by curses.wrapper to print output of func (called with terminal width and height, then args and kwargs) to terminal in less-style.
     :param func: function called to get output. Should return a triple (output, title, footer),
@@ -121,7 +121,7 @@ def _printer(stdscr: curses.window, run_event, func, *args, **kwargs):
         return
 
 
-def _print_to_scr(scr: curses.window, output, has_title):
+def _print_to_scr(scr, output, has_title):
     """
     Prints output to scr. Replaces color escape sequences with curses color escape sequences.
     """

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -171,17 +171,27 @@ def save_config(config):
             yaml.dump(config, config_file)
 
 
-def check_for_updates(current_version) -> Union[str, None]:
+def import_importlib_resources():
     """
-    Function to check if there is a new version of sinol-make.
-    :param current_version: current version of sinol-make
-    :return: returns new version if there is one, None otherwise
+    Function to import importlib_resources.
+    For Python 3.8 and below, we use importlib_resources.
+    For Python 3.9 and above, we use importlib.resources.
     """
     python_version = sys.version_info
     if python_version.minor <= 8:
         import importlib_resources as importlib
     else:
         import importlib.resources as importlib
+    return importlib
+
+
+def check_for_updates(current_version) -> Union[str, None]:
+    """
+    Function to check if there is a new version of sinol-make.
+    :param current_version: current version of sinol-make
+    :return: returns new version if there is one, None otherwise
+    """
+    importlib = import_importlib_resources()
 
     data_dir = importlib.files("sinol_make").joinpath("data")
     if not data_dir.is_dir():
@@ -210,11 +220,7 @@ def check_version():
     Function that asynchronously checks for new version of sinol-make.
     Writes the newest version to data/version file.
     """
-    python_version = sys.version_info
-    if python_version.minor <= 8:
-        import importlib_resources as importlib
-    else:
-        import importlib.resources as importlib
+    importlib = import_importlib_resources()
 
     try:
         request = requests.get("https://pypi.python.org/pypi/sinol-make/json", timeout=1)

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -1,7 +1,7 @@
 import glob, importlib, os, sys, subprocess, requests, tarfile, yaml
 import tempfile
-import importlib.resources
 import threading
+from typing import Union
 
 
 def get_commands():
@@ -171,13 +171,19 @@ def save_config(config):
             yaml.dump(config, config_file)
 
 
-def check_for_updates(current_version) -> str | None:
+def check_for_updates(current_version) -> Union[str, None]:
     """
     Function to check if there is a new version of sinol-make.
     :param current_version: current version of sinol-make
     :return: returns new version if there is one, None otherwise
     """
-    data_dir = importlib.resources.files("sinol_make").joinpath("data")
+    python_version = sys.version_info
+    if python_version.minor <= 8:
+        import importlib_resources as importlib
+    else:
+        import importlib.resources as importlib
+
+    data_dir = importlib.files("sinol_make").joinpath("data")
     if not data_dir.is_dir():
         os.mkdir(data_dir)
 
@@ -204,6 +210,12 @@ def check_version():
     Function that asynchronously checks for new version of sinol-make.
     Writes the newest version to data/version file.
     """
+    python_version = sys.version_info
+    if python_version.minor <= 8:
+        import importlib_resources as importlib
+    else:
+        import importlib.resources as importlib
+
     try:
         request = requests.get("https://pypi.python.org/pypi/sinol-make/json", timeout=1)
     except requests.exceptions.RequestException:
@@ -215,7 +227,7 @@ def check_version():
     data = request.json()
     latest_version = data["info"]["version"]
 
-    version_file = importlib.resources.files("sinol_make").joinpath("data/version")
+    version_file = importlib.files("sinol_make").joinpath("data/version")
     version_file.write_text(latest_version)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,7 +5,6 @@ import json
 import tempfile
 import requests
 import requests_mock
-import importlib.resources
 
 import pytest
 
@@ -81,7 +80,13 @@ def test_check_version(**kwargs):
     """
     mocker = kwargs["mocker"]
 
-    data_dir = importlib.resources.files('sinol_make').joinpath("data")
+    python_version = sys.version_info
+    if python_version.minor <= 8:
+        import importlib_resources as importlib
+    else:
+        import importlib.resources as importlib
+
+    data_dir = importlib.files('sinol_make').joinpath("data")
     version_file = data_dir.joinpath("version")
     if not data_dir.is_dir():
         data_dir.mkdir()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -80,11 +80,7 @@ def test_check_version(**kwargs):
     """
     mocker = kwargs["mocker"]
 
-    python_version = sys.version_info
-    if python_version.minor <= 8:
-        import importlib_resources as importlib
-    else:
-        import importlib.resources as importlib
+    importlib = util.import_importlib_resources()
 
     data_dir = importlib.files('sinol_make').joinpath("data")
     version_file = data_dir.joinpath("version")


### PR DESCRIPTION
There were some problems with types and `importlib.resources` in python 3.7 and 3.8. 