### PR TITLE
Change `time` installation steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ As `oiejq` works only on Linux-based operating systems,
 Nevertheless `sinol-make` supports those operating systems,
 though there are additional installation steps required to use
 other tools for measuring time (which are non-deterministic and produce reports different from sio2):
-- Windows (WSL): `apt install time`
+- Debian-based systems (Ubuntu, usually Windows WSL): `apt install time`
+- Arch-based systems: `pacman -S time`
 - macOS: `brew install gnu-time coreutils`
 
 ### Autocompletion (optional)


### PR DESCRIPTION
@tonowak could you test if `pacman -S time` installs `time` in /usr/bin/time correctly? I can't test it on my system at the moment