### PR TITLE
Fix compilation caching

### DIFF
--- a/src/sinol_make/helpers/compile.py
+++ b/src/sinol_make/helpers/compile.py
@@ -32,7 +32,6 @@ def check_compiled(file_path: str):
                 exe_path = info.get("executable_path", "")
                 if os.path.exists(exe_path):
                     return exe_path
-            os.unlink(info_file_path)
             return None
     except FileNotFoundError:
         return None

--- a/src/sinol_make/helpers/compile.py
+++ b/src/sinol_make/helpers/compile.py
@@ -12,15 +12,8 @@ from sinol_make.interfaces.Errors import CompilationError
 from sinol_make.structs.compiler_structs import Compilers
 
 
-def get_executable_info_file(file_path):
-    """
-    Calculate the md5 sum of file's content and return the path to file `cache/md5sums/<md5sum>`.
-    If this file exists it contains the path to the compiled executable.
-    Thanks to that, we cache the compiled solutions and recompile them when they change.
-    """
-    os.makedirs(os.path.join(os.getcwd(), 'cache', 'md5sums'), exist_ok=True)
-    md5sum = util.get_file_md5(file_path)
-    return os.path.join(os.getcwd(), 'cache', 'md5sums', md5sum)
+def create_compilation_cache():
+    os.makedirs(os.path.join(os.getcwd(), "cache", "md5sums"), exist_ok=True)
 
 
 def check_compiled(file_path: str):
@@ -29,31 +22,37 @@ def check_compiled(file_path: str):
     :param file_path: Path to the file
     :return: executable path if compiled, None otherwise
     """
-    info_file_path = get_executable_info_file(file_path)
-
+    create_compilation_cache()
+    md5sum = util.get_file_md5(file_path)
     try:
-        with open(info_file_path, 'r') as md5sums_file:
-            exe_file = md5sums_file.read().strip()
-            if os.path.exists(exe_file):
-                return exe_file
-            else:
-                os.unlink(info_file_path)
-                return None
+        info_file_path = os.path.join(os.getcwd(), "cache", "md5sums", os.path.basename(file_path))
+        with open(info_file_path, 'r') as info_file:
+            info = yaml.load(info_file, Loader=yaml.FullLoader)
+            if info.get("md5sum", "") == md5sum:
+                exe_path = info.get("executable_path", "")
+                if os.path.exists(exe_path):
+                    return exe_path
+            os.unlink(info_file_path)
+            return None
     except FileNotFoundError:
         return None
 
 
 def save_compiled(file_path: str, exe_path: str):
     """
-    Save the compiled executable path to cache in `cache/md5sums/<md5sum>`,
-    where <md5sum> is the md5 sum of the file's content.
+    Save the compiled executable path to cache in `cache/md5sums/<basename of file_path>`,
+    which contains the md5sum of the file and the path to the executable.
     :param file_path: Path to the file
     :param exe_path: Path to the compiled executable
     """
-    info_file_path = get_executable_info_file(file_path)
-
-    with open(info_file_path, 'w') as md5sums_file:
-        md5sums_file.write(exe_path)
+    create_compilation_cache()
+    info_file_path = os.path.join(os.getcwd(), "cache", "md5sums", os.path.basename(file_path))
+    info = {
+        "md5sum": util.get_file_md5(file_path),
+        "executable_path": exe_path
+    }
+    with open(info_file_path, 'w') as info_file:
+        yaml.dump(info, info_file)
 
 
 def compile(program, output, compilers: Compilers = None, compile_log = None, weak_compilation_flags = False,

--- a/tests/helpers/test_cache.py
+++ b/tests/helpers/test_cache.py
@@ -13,7 +13,7 @@ def test_compilation_caching():
         assert compile.check_compiled(program) is None
 
         assert compile.compile(program, os.path.join(tmpdir, 'program'), compile_log=None)
-        exe_path = compile.check_compiled(program) is not None
+        exe_path = compile.check_compiled(program)
         assert exe_path is not None
 
         assert compile.compile(program, os.path.join(tmpdir, 'program'), compile_log=None)

--- a/tests/helpers/test_cache.py
+++ b/tests/helpers/test_cache.py
@@ -6,6 +6,7 @@ from sinol_make.helpers import compile
 
 def test_compilation_caching():
     with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
         program = os.path.join(tmpdir, 'program.cpp')
         open(program, 'w').write('int main() { return 0; }')
 

--- a/tests/helpers/test_cache.py
+++ b/tests/helpers/test_cache.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+
+from sinol_make.helpers import compile
+
+
+def test_compilation_caching():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        program = os.path.join(tmpdir, 'program.cpp')
+        open(program, 'w').write('int main() { return 0; }')
+
+        assert compile.check_compiled(program) is None
+
+        assert compile.compile(program, os.path.join(tmpdir, 'program'), compile_log=None)
+        exe_path = compile.check_compiled(program) is not None
+        assert exe_path is not None
+
+        assert compile.compile(program, os.path.join(tmpdir, 'program'), compile_log=None)
+        exe_path2 = compile.check_compiled(program)
+        assert exe_path2 == exe_path
+
+        open(program, 'w').write('int main() { return 1; }')
+        assert compile.check_compiled(program) is None
+        assert compile.compile(program, os.path.join(tmpdir, 'program'), compile_log=None)
+        assert compile.check_compiled(program) is not None
+
+        open(program, 'w').write('int main() { return 0; }')
+        assert compile.check_compiled(program) is None
+        assert compile.compile(program, os.path.join(tmpdir, 'program'), compile_log=None)
+        assert compile.check_compiled(program) is not None


### PR DESCRIPTION
When a file with code A was compiled, the path to the executable was saved for md5sum of code A. Then after changing file's code to code B and compiling it, the executable's path is the same, but it's compiled with code B. The md5sum for code A is still stored. Then after changing file's code to code A again, `sinol-make` sees that there is a md5sum for code A and returns path to the executable, which is still compiled with code B.

Now, information about md5 sums for a file named `file.cpp` is stored in `.cache/md5sums/file.cpp`, which contains the md5sum of the code and path to the executable. This fixes the above problem, because after compiling the same file again, the previous md5sum is deleted.