### PR TITLE
Change c++ standard and default compilers

### DIFF
--- a/src/sinol_make/commands/export/__init__.py
+++ b/src/sinol_make/commands/export/__init__.py
@@ -90,8 +90,8 @@ class Command(BaseCommand):
         :param config: Config dictionary.
         """
         with open(os.path.join(target_dir, 'makefile.in'), 'w') as f:
-            cxx_flags = '-std=c++17'
-            c_flags = '-std=c17'
+            cxx_flags = '-std=c++20'
+            c_flags = '-std=gnu99'
             def format_multiple_arguments(obj):
                 if isinstance(obj, str):
                     return obj

--- a/src/sinol_make/helpers/compile.py
+++ b/src/sinol_make/helpers/compile.py
@@ -100,11 +100,11 @@ def compile(program, output, compilers: Compilers = None, compile_log = None, we
     if ext == '.cpp':
         arguments = [compilers.cpp_compiler_path or compiler.get_cpp_compiler_path(), program] + \
                     extra_compilation_args + ['-o', output] + \
-                    f'--std=c++17 -O3 -lm {gcc_compilation_flags} -fdiagnostics-color'.split(' ')
+                    f'--std=c++20 -O3 -lm {gcc_compilation_flags} -fdiagnostics-color'.split(' ')
     elif ext == '.c':
         arguments = [compilers.c_compiler_path or compiler.get_c_compiler_path(), program] + \
                     extra_compilation_args + ['-o', output] + \
-                    f'--std=c17 -O3 -lm {gcc_compilation_flags} -fdiagnostics-color'.split(' ')
+                    f'--std=gnu99 -O3 -lm {gcc_compilation_flags} -fdiagnostics-color'.split(' ')
     elif ext == '.py':
         if sys.platform == 'win32' or sys.platform == 'cygwin':
             # TODO: Make this work on Windows

--- a/src/sinol_make/helpers/compiler.py
+++ b/src/sinol_make/helpers/compiler.py
@@ -52,6 +52,8 @@ def get_cpp_compiler_path():
         else:
             return 'g++'
     elif sys.platform == 'darwin':
+        if check_if_installed('g++-12'):  # g++12 is currently the default compiler on sio.
+            return 'g++-12'
         for i in [9, 10, 11]:
             compiler = 'g++-' + str(i)
             if check_if_installed(compiler):
@@ -65,10 +67,12 @@ def get_python_interpreter_path():
     Get the Python interpreter
     """
 
-    if not check_if_installed('python3'):
-        return None
-    else:
-        return 'python3'
+    if check_if_installed('python3.11'):  # python3.11 is currently the default interpreter on sio.
+        return 'python3.11'
+    for ver in ['3.9', '3.8', '3.7', '3']:
+        if check_if_installed('python' + ver):
+            return 'python' + ver
+    return None
 
 
 def get_java_compiler_path():

--- a/tests/commands/export/util.py
+++ b/tests/commands/export/util.py
@@ -53,8 +53,8 @@ def assert_makefile_in(lines, task_id, config):
     assert _get_value_from_key("SLOW_TIMELIMIT", "=") == str(4 * config["time_limit"])
     assert _get_value_from_key("MEMLIMIT", "=") == str(config["memory_limit"])
 
-    cxx_flags = '-std=c++17'
-    c_flags = '-std=c17'
+    cxx_flags = '-std=c++20'
+    c_flags = '-std=gnu99'
     def format_multiple_arguments(obj):
         if isinstance(obj, str):
             return obj


### PR DESCRIPTION
From today, sio will by default use g++12, c++20 and python3.11