### PR TITLE
Check if files have correct permissions

### DIFF
--- a/src/sinol_make/helpers/cache.py
+++ b/src/sinol_make/helpers/cache.py
@@ -117,3 +117,17 @@ def remove_results_if_contest_type_changed(contest_type):
     if package_util.check_if_contest_type_changed(contest_type):
         remove_results_cache()
     package_util.save_contest_type_to_cache(contest_type)
+
+
+def check_can_access_cache():
+    """
+    Checks if user can access cache.
+    """
+    try:
+        os.makedirs(paths.get_cache_path(), exist_ok=True)
+        with open(paths.get_cache_path("test"), "w") as f:
+            f.write("test")
+        os.unlink(paths.get_cache_path("test"))
+    except PermissionError:
+        util.exit_with_error("You don't have permission to access the `.cache/` directory. "
+                             "`sinol-make` needs to be able to write to this directory.")

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -10,6 +10,7 @@ from typing import Union
 
 import sinol_make
 from sinol_make.contest_types import get_contest_type
+from sinol_make.helpers import paths, cache
 from sinol_make.structs.status_structs import Status
 
 
@@ -54,6 +55,7 @@ def exit_if_not_package():
     """
     if not find_and_chdir_package():
         exit_with_error('You are not in a package directory (couldn\'t find config.yml in current directory).')
+    cache.check_can_access_cache()
 
 
 def save_config(config):
@@ -141,16 +143,21 @@ def check_for_updates(current_version) -> Union[str, None]:
     thread.start()
     version_file = data_dir.joinpath("version")
 
-    if version_file.is_file():
+    try:
         version = version_file.read_text()
+    except PermissionError:
         try:
-            if compare_versions(current_version, version) == -1:
-                return version
-            else:
-                return None
-        except ValueError:  # If the version file is corrupted, we just ignore it.
+            with open(paths.get_cache_path("sinol_make_version"), "r") as f:
+                version = f.read()
+        except (FileNotFoundError, PermissionError):
             return None
-    else:
+
+    try:
+        if compare_versions(current_version, version) == -1:
+            return version
+        else:
+            return None
+    except ValueError:  # If the version file is corrupted, we just ignore it.
         return None
 
 
@@ -173,7 +180,16 @@ def check_version():
     latest_version = data["info"]["version"]
 
     version_file = importlib.files("sinol_make").joinpath("data/version")
-    version_file.write_text(latest_version)
+    try:
+        version_file.write_text(latest_version)
+    except PermissionError:
+        if find_and_chdir_package():
+            try:
+                os.makedirs(paths.get_cache_path(), exist_ok=True)
+                with open(paths.get_cache_path("sinol_make_version"), "w") as f:
+                    f.write(latest_version)
+            except PermissionError:
+                pass
 
 
 def compare_versions(version_a, version_b):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,6 +11,7 @@ import pytest
 import yaml
 
 from sinol_make import util, configure_parsers
+from sinol_make.helpers import paths
 from tests import util as test_util
 from tests.fixtures import create_package
 from tests.commands.run import util as run_util
@@ -79,6 +80,9 @@ def test_check_version(**kwargs):
     version_file = data_dir.joinpath("version")
     if not data_dir.is_dir():
         data_dir.mkdir()
+    data_dir.chmod(0o777)
+    if version_file.is_file():
+        version_file.unlink()
 
     # Test correct request
     mocker.get("https://pypi.python.org/pypi/sinol-make/json", json={"info": {"version": "1.0.0"}})
@@ -96,6 +100,37 @@ def test_check_version(**kwargs):
     mocker.get("https://pypi.python.org/pypi/sinol-make/json", exc=requests.exceptions.ConnectTimeout)
     util.check_version()
     assert not version_file.is_file()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        with open("config.yml", "w") as config_file:
+            config_file.write("")
+
+        # No permission to write
+        version_file.write_text("0.0.0")
+        version_file.chmod(0o000)
+        mocker.get("https://pypi.python.org/pypi/sinol-make/json", json={"info": {"version": "1.0.0"}})
+        util.check_version()
+        assert version_file.is_file()
+        version_file.chmod(0o777)
+        assert version_file.read_text() == "0.0.0"
+        assert os.path.exists(paths.get_cache_path("sinol_make_version"))
+        with open(paths.get_cache_path("sinol_make_version"), "r") as f:
+            assert f.read() == "1.0.0"
+
+        # No permission to write to cache and data dir
+        with open(paths.get_cache_path("sinol_make_version"), "w") as f:
+            f.write("0.0.0")
+        os.chmod(paths.get_cache_path("sinol_make_version"), 0o000)
+        os.chmod(paths.get_cache_path(), 0o000)
+        os.chmod(data_dir, 0o000)
+        version_file.chmod(0o000)
+        mocker.get("https://pypi.python.org/pypi/sinol-make/json", json={"info": {"version": "1.0.0"}})
+        util.check_version()
+        os.chmod(data_dir, 0o777)
+        version_file.chmod(0o777)
+        assert version_file.is_file()
+        assert version_file.read_text() == "0.0.0"
 
 
 @pytest.mark.parametrize("create_package", [test_util.get_simple_package_path()], indirect=True)


### PR DESCRIPTION
Now the script checks if the file with `sinol-make` version has write and read permissions, and if not it tries to save the information in `.cache` directory.
Also added a check if `.cache` has correct permissions.