### PR TITLE
After running `sinol-make doc` remove log files

### DIFF
--- a/src/sinol_make/__init__.py
+++ b/src/sinol_make/__init__.py
@@ -9,7 +9,7 @@ import os
 from sinol_make import util, oiejq
 
 
-__version__ = "1.5.11"
+__version__ = "1.5.12"
 
 
 def configure_parsers():

--- a/src/sinol_make/commands/doc/__init__.py
+++ b/src/sinol_make/commands/doc/__init__.py
@@ -11,6 +11,7 @@ class Command(BaseCommand):
     """
     Class for `doc` command.
     """
+    LOG_PATTERNS = ['*~', '*.aux', '*.log', '*.dvi', '*.err', '*.inf']
 
     def get_name(self):
         return "doc"
@@ -32,6 +33,11 @@ class Command(BaseCommand):
         print(util.info(f'Compilation successful for file {os.path.basename(file_path)}.'))
         return True
 
+    def delete_logs(self):
+        for pattern in self.LOG_PATTERNS:
+            for file in glob.glob(os.path.join(os.getcwd(), 'doc', pattern)):
+                os.remove(file)
+
     def configure_subparser(self, subparser: argparse.ArgumentParser):
         parser = subparser.add_parser(
             self.get_name(),
@@ -39,6 +45,7 @@ class Command(BaseCommand):
             description='Compiles latex files to pdf. By default compiles all files in the `doc` directory.\n'
                         'You can also specify files to compile.')
         parser.add_argument('files', type=str, nargs='*', help='files to compile')
+        parser.add_argument('-l', '--logs', action='store_true', help="don't delete logs after compilation")
 
     def run(self, args: argparse.Namespace):
         util.exit_if_not_package()
@@ -68,4 +75,6 @@ class Command(BaseCommand):
                 print(util.error(f'Failed to compile {failed_file}'))
             util.exit_with_error('Compilation failed.')
         else:
+            if not args.logs:
+                self.delete_logs()
             print(util.info('Compilation was successful for all files.'))

--- a/tests/commands/doc/test_integration.py
+++ b/tests/commands/doc/test_integration.py
@@ -4,6 +4,7 @@ import pytest
 
 from sinol_make import configure_parsers
 from sinol_make.commands.doc import Command
+from sinol_make.helpers import paths
 from tests.fixtures import create_package
 from tests import util
 
@@ -36,20 +37,9 @@ def test_argument(capsys, create_package):
     out = capsys.readouterr().out
     assert "Compilation was successful for all files." in out
 
+    logs_exist = False
+    logs_dir = paths.get_cache_path('doc_logs')
     for pattern in command.LOG_PATTERNS:
         assert glob.glob(os.path.join(os.getcwd(), 'doc', pattern)) == []
-
-
-@pytest.mark.parametrize("create_package", [util.get_doc_package_path()], indirect=True)
-def test_logs_flag(create_package):
-    """
-    Test --logs flag.
-    """
-    parser = configure_parsers()
-    args = parser.parse_args(["doc", "--logs"])
-    command = Command()
-    command.run(args)
-
-    for pattern in command.LOG_PATTERNS:
-        for file in glob.glob(os.path.join(os.getcwd(), 'doc', pattern)):
-            assert os.path.exists(file)
+        logs_exist = logs_exist | (glob.glob(os.path.join(logs_dir, pattern)) != [])
+    assert logs_exist

--- a/tests/commands/doc/test_integration.py
+++ b/tests/commands/doc/test_integration.py
@@ -1,3 +1,5 @@
+import os
+import glob
 import pytest
 
 from sinol_make import configure_parsers
@@ -18,6 +20,9 @@ def test_simple(capsys, create_package):
     out = capsys.readouterr().out
     assert "Compilation was successful for all files." in out
 
+    for pattern in command.LOG_PATTERNS:
+        assert glob.glob(os.path.join(os.getcwd(), 'doc', pattern)) == []
+
 
 @pytest.mark.parametrize("create_package", [util.get_doc_package_path()], indirect=True)
 def test_argument(capsys, create_package):
@@ -30,3 +35,21 @@ def test_argument(capsys, create_package):
     command.run(args)
     out = capsys.readouterr().out
     assert "Compilation was successful for all files." in out
+
+    for pattern in command.LOG_PATTERNS:
+        assert glob.glob(os.path.join(os.getcwd(), 'doc', pattern)) == []
+
+
+@pytest.mark.parametrize("create_package", [util.get_doc_package_path()], indirect=True)
+def test_logs_flag(create_package):
+    """
+    Test --logs flag.
+    """
+    parser = configure_parsers()
+    args = parser.parse_args(["doc", "--logs"])
+    command = Command()
+    command.run(args)
+
+    for pattern in command.LOG_PATTERNS:
+        for file in glob.glob(os.path.join(os.getcwd(), 'doc', pattern)):
+            assert os.path.exists(file)


### PR DESCRIPTION
Now after running `sinol-make doc` all compilation logs are removed, unless `--logs` flag is set. Closes #139 