### PR TITLE
Add an optional argument to fix deprecated warning in Python 3.12

### DIFF
--- a/src/sinol_make/oiejq/__init__.py
+++ b/src/sinol_make/oiejq/__init__.py
@@ -73,7 +73,7 @@ def install_oiejq():
             oiejq_file.write(request.content)
 
         with tarfile.open(oiejq_path) as tar:
-            tar.extractall(path=tmpdir)
+            util.extract_tar(tar, tmpdir)
         shutil.copy(os.path.join(tmpdir, 'oiejq', 'oiejq.sh'), os.path.expanduser('~/.local/bin/oiejq'))
         shutil.copy(os.path.join(tmpdir, 'oiejq', 'sio2jail'), os.path.expanduser('~/.local/bin/'))
 

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -1,5 +1,6 @@
 import glob, importlib, os, sys, requests, yaml
 import platform
+import tarfile
 import tempfile
 import shutil
 import hashlib
@@ -360,6 +361,13 @@ def try_fix_config(config):
             del config["sinol_expected_scores"]
             save_config(config)
     return config
+
+
+def extract_tar(tar: tarfile.TarFile, destination: str):
+    if sys.version_info.major == 3 and sys.version_info.minor >= 12:
+        tar.extractall(destination, filter='tar')
+    else:
+        tar.extractall(destination)
 
 
 def color_red(text): return "\033[91m{}\033[00m".format(text)

--- a/tests/commands/export/test_integration.py
+++ b/tests/commands/export/test_integration.py
@@ -6,6 +6,7 @@ import tarfile
 import tempfile
 
 from sinol_make import configure_parsers
+from sinol_make import util as sinol_util
 from sinol_make.commands.doc import Command as DocCommand
 from tests import util
 from tests.fixtures import create_package
@@ -19,7 +20,7 @@ def _test_archive(package_path, out, tar):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         with tarfile.open(tar, "r") as tar:
-            tar.extractall(tmpdir)
+            sinol_util.extract_tar(tar, tmpdir)
 
         extracted = os.path.join(tmpdir, task_id)
         assert os.path.exists(extracted)
@@ -75,7 +76,7 @@ def test_doc_cleared(create_package):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         with tarfile.open(f'{package_util.get_task_id()}.tgz', "r") as tar:
-            tar.extractall(tmpdir)
+            sinol_util.extract_tar(tar, tmpdir)
 
         extracted = os.path.join(tmpdir, package_util.get_task_id())
         assert os.path.exists(extracted)
@@ -100,7 +101,7 @@ def test_correct_permissions(create_package, capsys):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         with tarfile.open(f'{task_id}.tgz', "r") as tar:
-            tar.extractall(tmpdir)
+            sinol_util.extract_tar(tar, tmpdir)
 
         shell_ingen = os.path.join(tmpdir, task_id, 'prog', f'{task_id}ingen.sh')
         assert os.path.exists(shell_ingen)


### PR DESCRIPTION
Python 3.12 added new argument to `tar.extractall` which specifies how the tar files should be handled. When this arguments is not passed `DeprecationWarning` is shown. To fix this, I added a function that passes this argument if the python version is 3.12. Here are informations about this new argument https://docs.python.org/3/library/tarfile.html#extraction-filters