### PR TITLE
Change default number of cpus

### DIFF
--- a/src/sinol_make/commands/gen/__init__.py
+++ b/src/sinol_make/commands/gen/__init__.py
@@ -35,7 +35,8 @@ class Command(BaseCommand):
         parser.add_argument('ingen_path', type=str, nargs='?',
                             help='path to ingen source file, for example prog/abcingen.cpp')
         parser.add_argument('-c', '--cpus', type=int,
-                            help=f'number of cpus to use to generate output files (default: {mp.cpu_count()} - all available)',
+                            help=f'number of cpus to use to generate output files '
+                                 f'(default: {mp.cpu_count() - 1})',
                             default=mp.cpu_count())
         parsers.add_compilation_arguments(parser)
 

--- a/src/sinol_make/commands/gen/__init__.py
+++ b/src/sinol_make/commands/gen/__init__.py
@@ -36,8 +36,8 @@ class Command(BaseCommand):
                             help='path to ingen source file, for example prog/abcingen.cpp')
         parser.add_argument('-c', '--cpus', type=int,
                             help=f'number of cpus to use to generate output files '
-                                 f'(default: {mp.cpu_count() - 1})',
-                            default=mp.cpu_count())
+                                 f'(default: {util.default_cpu_count()})',
+                            default=util.default_cpu_count())
         parsers.add_compilation_arguments(parser)
 
     def generate_outputs(self, outputs_to_generate):

--- a/src/sinol_make/commands/inwer/__init__.py
+++ b/src/sinol_make/commands/inwer/__init__.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         parser.add_argument('-t', '--tests', type=str, nargs='+',
                             help='test to verify, for example in/abc{0,1}*')
         parser.add_argument('-c', '--cpus', type=int,
-                            help=f'number of cpus to use (default: {mp.cpu_count() - 1})')
+                            help=f'number of cpus to use (default: {util.default_cpu_count()})')
         add_compilation_arguments(parser)
 
     def compile_inwer(self, args: argparse.Namespace):
@@ -133,7 +133,7 @@ class Command(BaseCommand):
         relative_path = os.path.relpath(self.inwer, os.getcwd())
         print(f'Verifying with inwer {util.bold(relative_path)}')
 
-        self.cpus = args.cpus or mp.cpu_count()
+        self.cpus = args.cpus or util.default_cpu_count()
         self.tests = package_util.get_tests(self.task_id, args.tests)
 
         if len(self.tests) == 0:

--- a/src/sinol_make/commands/inwer/__init__.py
+++ b/src/sinol_make/commands/inwer/__init__.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         parser.add_argument('-t', '--tests', type=str, nargs='+',
                             help='test to verify, for example in/abc{0,1}*')
         parser.add_argument('-c', '--cpus', type=int,
-                            help=f'number of cpus to use (default: {mp.cpu_count()} -all available)')
+                            help=f'number of cpus to use (default: {mp.cpu_count() - 1})')
         add_compilation_arguments(parser)
 
     def compile_inwer(self, args: argparse.Namespace):

--- a/src/sinol_make/commands/run/__init__.py
+++ b/src/sinol_make/commands/run/__init__.py
@@ -252,7 +252,7 @@ class Command(BaseCommand):
         parser.add_argument('-t', '--tests', type=str, nargs='+',
                             help='tests to be run, for example in/abc{0,1}*')
         parser.add_argument('-c', '--cpus', type=int,
-                            help=f'number of cpus to use (default: {mp.cpu_count() - 1}')
+                            help=f'number of cpus to use (default: {util.default_cpu_count()}')
         parser.add_argument('--tl', type=float, help='time limit for all tests (in s)')
         parser.add_argument('--ml', type=float, help='memory limit for all tests (in MB)')
         parser.add_argument('--hide-memory', dest='hide_memory', action='store_true',
@@ -1146,7 +1146,7 @@ class Command(BaseCommand):
 
         title = self.config["title"]
         print("Task: %s (tag: %s)" % (title, self.ID))
-        self.cpus = args.cpus or mp.cpu_count()
+        self.cpus = args.cpus or util.default_cpu_count()
         cache.save_to_cache_extra_compilation_files(self.config.get("extra_compilation_files", []), self.ID)
         cache.remove_results_if_contest_type_changed(self.config.get("sinol_contest_type", "default"))
 

--- a/src/sinol_make/commands/run/__init__.py
+++ b/src/sinol_make/commands/run/__init__.py
@@ -252,7 +252,7 @@ class Command(BaseCommand):
         parser.add_argument('-t', '--tests', type=str, nargs='+',
                             help='tests to be run, for example in/abc{0,1}*')
         parser.add_argument('-c', '--cpus', type=int,
-                            help='number of cpus to use, you have %d avaliable' % mp.cpu_count())
+                            help=f'number of cpus to use (default: {mp.cpu_count() - 1}')
         parser.add_argument('--tl', type=float, help='time limit for all tests (in s)')
         parser.add_argument('--ml', type=float, help='memory limit for all tests (in MB)')
         parser.add_argument('--hide-memory', dest='hide_memory', action='store_true',

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -1,4 +1,6 @@
 import glob, importlib, os, sys, requests, yaml
+import math
+import multiprocessing
 import platform
 import tarfile
 import tempfile
@@ -368,6 +370,16 @@ def extract_tar(tar: tarfile.TarFile, destination: str):
         tar.extractall(destination, filter='tar')
     else:
         tar.extractall(destination)
+
+
+def default_cpu_count():
+    """
+    Function to get default number of cpus to use for multiprocessing.
+    """
+    cpu_count = multiprocessing.cpu_count()
+    if cpu_count == 1:
+        return 1
+    return cpu_count - max(1, int(math.log2(cpu_count)) - 1)
 
 
 def color_red(text): return "\033[91m{}\033[00m".format(text)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import pytest
 import multiprocessing as mp
 
+from sinol_make import util
 from sinol_make.helpers import compile, paths
 from sinol_make.interfaces.Errors import CompilationError
 
@@ -34,7 +35,7 @@ def pytest_addoption(parser):
     )
     parser.addoption("--no-precompile", action="store_true", help="if set, will not precompile all solutions")
     parser.addoption("--cpus", type=int, help="number of cpus to use, by default all available",
-                     default=mp.cpu_count() - 1)
+                     default=util.default_cpu_count())
 
 
 def pytest_configure(config):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def pytest_addoption(parser):
     )
     parser.addoption("--no-precompile", action="store_true", help="if set, will not precompile all solutions")
     parser.addoption("--cpus", type=int, help="number of cpus to use, by default all available",
-                     default=mp.cpu_count())
+                     default=mp.cpu_count() - 1)
 
 
 def pytest_configure(config):


### PR DESCRIPTION
Now the default value for --cpus flag will be the number of cpus - 1.

Closes #153 