### PR TITLE
Allow generating only ins/outs in `gen` command

### DIFF
--- a/src/sinol_make/__init__.py
+++ b/src/sinol_make/__init__.py
@@ -9,7 +9,7 @@ import os
 from sinol_make import util, oiejq
 
 
-__version__ = "1.5.13"
+__version__ = "1.5.14"
 
 
 def configure_parsers():

--- a/src/sinol_make/commands/gen/__init__.py
+++ b/src/sinol_make/commands/gen/__init__.py
@@ -34,8 +34,8 @@ class Command(BaseCommand):
 
         parser.add_argument('ingen_path', type=str, nargs='?',
                             help='path to ingen source file, for example prog/abcingen.cpp')
-        parser.add_argument('-i', '--ins', action='store_true', help='generate input files only')
-        parser.add_argument('-o', '--outs', action='store_true', help='generate output files only')
+        parser.add_argument('-i', '--only-inputs', action='store_true', help='generate input files only')
+        parser.add_argument('-o', '--only-outputs', action='store_true', help='generate output files only')
         parser.add_argument('-c', '--cpus', type=int,
                             help=f'number of cpus to use to generate output files (default: {mp.cpu_count()} - all available)',
                             default=mp.cpu_count())
@@ -97,8 +97,8 @@ class Command(BaseCommand):
         util.exit_if_not_package()
 
         self.args = args
-        self.ins = args.ins
-        self.outs = args.outs
+        self.ins = args.only_inputs
+        self.outs = args.only_outputs
         # If no arguments are specified, generate both input and output files.
         if not self.ins and not self.outs:
             self.ins = True

--- a/tests/commands/gen/test_integration.py
+++ b/tests/commands/gen/test_integration.py
@@ -110,7 +110,7 @@ def test_ins_flag(create_package):
     outs = glob.glob(os.path.join(create_package, "out", "*.out"))
     assert len(ins) > 0
     assert len(outs) == 0
-    assert os.path.exists(os.path.join(create_package, "in", ".md5sums"))
+    assert not os.path.exists(os.path.join(create_package, "in", ".md5sums"))
 
 @pytest.mark.parametrize("create_package", [util.get_shell_ingen_pack_path(), util.get_simple_package_path()],
                             indirect=True)

--- a/tests/commands/gen/test_integration.py
+++ b/tests/commands/gen/test_integration.py
@@ -101,11 +101,11 @@ def test_shell_ingen_unchanged(create_package):
 
 @pytest.mark.parametrize("create_package", [util.get_shell_ingen_pack_path(), util.get_simple_package_path()],
                          indirect=True)
-def test_ins_flag(create_package):
+def test_only_inputs_flag(create_package):
     """
-    Test if `--ins` flag works.
+    Test if `--only-inputs` flag works.
     """
-    simple_run(["--ins"])
+    simple_run(["--only-inputs"])
     ins = glob.glob(os.path.join(create_package, "in", "*.in"))
     outs = glob.glob(os.path.join(create_package, "out", "*.out"))
     assert len(ins) > 0
@@ -114,11 +114,11 @@ def test_ins_flag(create_package):
 
 @pytest.mark.parametrize("create_package", [util.get_shell_ingen_pack_path(), util.get_simple_package_path()],
                             indirect=True)
-def test_outs_flag(create_package):
+def test_only_outputs_flag(create_package):
     """
-    Test if `--outs` flag works.
+    Test if `--only-outputs` flag works.
     """
-    simple_run(['--ins'])
+    simple_run(['--only-inputs'])
     ins = glob.glob(os.path.join(create_package, "in", "*.in"))
     outs = glob.glob(os.path.join(create_package, "out", "*.out"))
     in1 = ins[0]
@@ -128,7 +128,7 @@ def test_outs_flag(create_package):
     def in_to_out(file):
         return os.path.join(create_package, "out", os.path.basename(file).replace(".in", ".out"))
 
-    simple_run(["--outs"])
+    simple_run(["--only-outputs"])
     ins = glob.glob(os.path.join(create_package, "in", "*.in"))
     outs = glob.glob(os.path.join(create_package, "out", "*.out"))
     assert len(ins) == 1
@@ -143,7 +143,7 @@ def test_missing_output_files(create_package):
     Test if `ingen` command generates missing output files.
     """
     package_path = create_package
-    for args in [[], ["--outs"]]:
+    for args in [[], ["--only-outputs"]]:
         simple_run()
         outs = glob.glob(os.path.join(package_path, "out", "*.out"))
         os.unlink(outs[0])


### PR DESCRIPTION
Requested in #154. I added flags `--ins` and `--outs` for generating only inputs/outputs. Also, if for some input file an output file doesn't exist, it is generated.