### PR TITLE
Remove tests cache on correct solution change

### DIFF
--- a/src/sinol_make/commands/gen/__init__.py
+++ b/src/sinol_make/commands/gen/__init__.py
@@ -8,7 +8,7 @@ import multiprocessing as mp
 from sinol_make import util
 from sinol_make.commands.gen import gen_util
 from sinol_make.structs.gen_structs import OutputGenerationArguments
-from sinol_make.helpers import parsers, package_util
+from sinol_make.helpers import parsers, package_util, cache
 from sinol_make.interfaces.BaseCommand import BaseCommand
 
 
@@ -108,6 +108,7 @@ class Command(BaseCommand):
         self.task_id = package_util.get_task_id()
         package_util.validate_test_names(self.task_id)
         util.change_stack_size_to_unlimited()
+        cache.check_correct_solution(self.task_id)
         if self.ins:
             self.ingen = gen_util.get_ingen(self.task_id, args.ingen_path)
             print(util.info(f'Using ingen file {os.path.basename(self.ingen)}'))

--- a/src/sinol_make/helpers/cache.py
+++ b/src/sinol_make/helpers/cache.py
@@ -131,3 +131,31 @@ def check_can_access_cache():
     except PermissionError:
         util.exit_with_error("You don't have permission to access the `.cache/` directory. "
                              "`sinol-make` needs to be able to write to this directory.")
+
+
+def has_file_changed(file_path: str) -> bool:
+    """
+    Checks if file has changed since last compilation.
+    :param file_path: Path to the file
+    :return: True if file has changed, False otherwise
+    """
+    try:
+        info = get_cache_file(file_path)
+        return info.md5sum != util.get_file_md5(file_path)
+    except FileNotFoundError:
+        return True
+
+
+def check_correct_solution(task_id: str):
+    """
+    Checks if correct solution has changed. If it did, removes cache for input files.
+    :param task_id: Task id
+    """
+    try:
+        solution = package_util.get_correct_solution(task_id)
+    except FileNotFoundError:
+        return
+
+    if has_file_changed(solution):
+        if os.path.exists(os.path.join(os.getcwd(), 'in', '.md5sums')):
+            os.unlink(os.path.join(os.getcwd(), 'in', '.md5sums'))

--- a/src/sinol_make/helpers/cache.py
+++ b/src/sinol_make/helpers/cache.py
@@ -156,6 +156,5 @@ def check_correct_solution(task_id: str):
     except FileNotFoundError:
         return
 
-    if has_file_changed(solution):
-        if os.path.exists(os.path.join(os.getcwd(), 'in', '.md5sums')):
-            os.unlink(os.path.join(os.getcwd(), 'in', '.md5sums'))
+    if has_file_changed(solution) and os.path.exists(os.path.join(os.getcwd(), 'in', '.md5sums')):
+        os.unlink(os.path.join(os.getcwd(), 'in', '.md5sums'))

--- a/src/sinol_make/helpers/package_util.py
+++ b/src/sinol_make/helpers/package_util.py
@@ -146,6 +146,18 @@ def get_solutions(task_id: str, args_solutions: Union[List[str], None] = None) -
         return sorted(solutions, key=lambda solution: get_executable_key(solution, task_id))
 
 
+def get_correct_solution(task_id: str) -> str:
+    """
+    Returns path to correct solution.
+    :param task_id: Task id.
+    :return: Path to correct solution.
+    """
+    correct_solution = get_solutions(task_id, [f'{task_id}.*'])
+    if len(correct_solution) == 0:
+        raise FileNotFoundError("Correct solution not found.")
+    return os.path.join(os.getcwd(), "prog", correct_solution[0])
+
+
 def get_file_name(file_path):
     return os.path.split(file_path)[1]
 


### PR DESCRIPTION
If the correct solution is changed, the tests cache should be deleted, so that all output tests are regenerated. This didn't happen previously, this PR fixes that.