### PR TITLE
Fix get_group to comply with oioioi standards

### DIFF
--- a/src/sinol_make/commands/run/__init__.py
+++ b/src/sinol_make/commands/run/__init__.py
@@ -302,9 +302,7 @@ class Command(BaseCommand):
 
 
     def get_group(self, test_path):
-        if package_util.extract_test_id(test_path, self.ID).endswith("ocen"):
-            return 0
-        return int("".join(filter(str.isdigit, package_util.extract_test_id(test_path, self.ID))))
+        return package_util.get_group(test_path, self.ID)
 
 
     def get_solution_from_exe(self, executable):

--- a/src/sinol_make/helpers/package_util.py
+++ b/src/sinol_make/helpers/package_util.py
@@ -38,7 +38,7 @@ def extract_test_id(test_path, task_id):
 def get_group(test_path, task_id):
     if extract_test_id(test_path, task_id).endswith("ocen"):
         return 0
-    return int("".join(filter(str.isdigit, extract_test_id(test_path, task_id))))
+    return int("".join(re.search(r'\d+',extract_test_id(test_path, task_id)).group()))
 
 
 def get_groups(tests, task_id):


### PR DESCRIPTION
On sio tests in format abc1a1 belong in the test group 1. This PR should make the script consistent with oioioi when assigning test to groups .