### PR TITLE
Make the oiejq tests less flaky

### DIFF
--- a/src/sinol_make/commands/run/__init__.py
+++ b/src/sinol_make/commands/run/__init__.py
@@ -429,6 +429,7 @@ class Command(BaseCommand):
         env = os.environ.copy()
         env["MEM_LIMIT"] = f'{memory_limit}K'
         env["MEASURE_MEM"] = "1"
+        env["UNDER_OIEJQ"] = "1"
 
         timeout = False
         with open(input_file_path, "r") as input_file, open(output_file_path, "w") as output_file, \

--- a/tests/packages/lim/prog/lim2.cpp
+++ b/tests/packages/lim/prog/lim2.cpp
@@ -4,10 +4,21 @@
 using namespace std;
 using namespace std::chrono;
 
-int wait(int milisecs) {
+__attribute__((optimize("O0")))
+void s2j_wait(long long instructions) {
+    instructions /= 3; // Every pass of the loop below takes 3 instructions.
+    while (instructions > 0)
+        --instructions;
+}
+
+int wait(int secs) {
+    if (getenv("UNDER_OIEJQ") != NULL) {
+        s2j_wait((long long)secs * 2'000'000'000);
+        return 0;
+    }
     auto start = high_resolution_clock::now();
     int i = 0;
-    while (duration_cast<milliseconds>(high_resolution_clock::now() - start).count() < milisecs)
+    while (duration_cast<seconds>(high_resolution_clock::now() - start).count() < secs)
         i++;
     return i;
 }
@@ -17,11 +28,11 @@ int main() {
     cin >> a >> b;
 
     if (a == 2 && b == 1) {
-        int i = wait(7000);
+        int i = wait(7);
         a += i - i;
     }
     else {
-        int i = wait(2000);
+        int i = wait(2);
         a += i - i;
     }
 

--- a/tests/packages/ovl/prog/ovl.cpp
+++ b/tests/packages/ovl/prog/ovl.cpp
@@ -4,7 +4,18 @@
 using namespace std;
 using namespace std::chrono;
 
+__attribute__((optimize("O0")))
+void s2j_wait(long long instructions) {
+    instructions /= 3; // Every pass of the loop below takes 3 instructions.
+    while (instructions > 0)
+        --instructions;
+}
+
 int wait(int secs) {
+    if (getenv("UNDER_OIEJQ") != NULL) {
+        s2j_wait((long long)secs * 2'000'000'000);
+        return 0;
+    }
     auto start = high_resolution_clock::now();
     int i = 0;
     while (duration_cast<seconds>(high_resolution_clock::now() - start).count() < secs)

--- a/tests/packages/vso/prog/vso4.cpp
+++ b/tests/packages/vso/prog/vso4.cpp
@@ -14,7 +14,18 @@ int rnd() {
     return rand() % 100;
 }
 
+__attribute__((optimize("O0")))
+void s2j_wait(long long instructions) {
+    instructions /= 3; // Every pass of the loop below takes 3 instructions.
+    while (instructions > 0)
+        --instructions;
+}
+
 int wait(int secs) {
+    if (getenv("UNDER_OIEJQ") != NULL) {
+        s2j_wait((long long)secs * 2'000'000'000);
+        return 0;
+    }
     auto start = high_resolution_clock::now();
     int i = 0;
     while (duration_cast<seconds>(high_resolution_clock::now() - start).count() < secs)

--- a/tests/packages/vso/prog/vso7.cpp
+++ b/tests/packages/vso/prog/vso7.cpp
@@ -14,7 +14,18 @@ int rnd() {
     return rand() % 100;
 }
 
+__attribute__((optimize("O0")))
+void s2j_wait(long long instructions) {
+    instructions /= 3; // Every pass of the loop below takes 3 instructions.
+    while (instructions > 0)
+        --instructions;
+}
+
 int wait(int secs) {
+    if (getenv("UNDER_OIEJQ") != NULL) {
+        s2j_wait((long long)secs * 2'000'000'000);
+        return 0;
+    }
     auto start = high_resolution_clock::now();
     int i = 0;
     while (duration_cast<seconds>(high_resolution_clock::now() - start).count() < secs)


### PR DESCRIPTION
This makes some test solutions run for a given amount of seconds properly under oiejq by running a loop bounded by the number of instructions executed.
On faster computers, which execute more instructions per second, the previous behaviour of looping for an amount of real time caused undesired TLE results, which made some tests fail.