### PR TITLE
Add support for tox and paralell pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@ __pycache__
 src/sinol_make/data
 
 # pytest-cov
-.coverage
+.coverage*
 coverage.xml
+
+/.tox/

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ where = src
 tests =
     pytest
     pytest-cov
+    pytest-xdist
     requests-mock
 
 [options.entry_points]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py37,py312
+
+[testenv]
+extras = tests
+commands = pytest --cov=./ {posargs}


### PR DESCRIPTION
The ability to run pytest in paralell (`-n auto`) makes running the test suite locally more bearable.
When I ran it this way with #187 and #188, there were no failures during 20 full runs, so it seems quite stable (unlike oioioi...).

As for tox, it is already used in other sio2project repositories and it spares the effort of having to setup a venv or sth.