### PR TITLE
Fix the python package's license classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ project_urls =
     Homepage = https://github.com/sio2project/sinol-make
 classifiers =
     Programming Language :: Python :: 3
-    License :: OSI Approved :: MIT License
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Operating System :: OS Independent
 
 [options]


### PR DESCRIPTION
This repository [seems to be](https://github.com/sio2project/sinol-make/blob/main/LICENSE) licensed under GPLv3, but the license classifier in setup.py says otherwise, which this PR fixes.