### PR TITLE
Fix triggering github actions on pull requests

### DIFF
--- a/.github/workflows/Arch.yaml
+++ b/.github/workflows/Arch.yaml
@@ -1,6 +1,6 @@
 name: pytest-arch
 run-name: Run pytest on Arch Linux
-on: [push]
+on: [push, pull_request]
 jobs:
   pytest:
     runs-on: self-hosted

--- a/.github/workflows/GithubRunner.yaml
+++ b/.github/workflows/GithubRunner.yaml
@@ -1,6 +1,6 @@
 name: pytest-github-runner
 run-name: Run tests for GitHub Runner
-on: [push]
+on: [push, pull_request]
 jobs:
   pytest:
     strategy:

--- a/.github/workflows/Ubuntu.yaml
+++ b/.github/workflows/Ubuntu.yaml
@@ -1,6 +1,6 @@
 name: pytest-ubuntu
 run-name: Run pytest on Ubuntu
-on: [push]
+on: [push, pull_request]
 jobs:
   pytest:
     runs-on: self-hosted

--- a/.github/workflows/macOS.yaml
+++ b/.github/workflows/macOS.yaml
@@ -1,6 +1,6 @@
 name: pytest-macos
 run-name: Run pytest on macOS
-on: [push]
+on: [push, pull_request]
 
 jobs:
   pytest:


### PR DESCRIPTION
Previously, only pull requests from a branch of this repository were triggering github action workflows.
Adding `pull_request` to the triggers fixes this.