### PR TITLE
Fix saving configs with unicode characters

### DIFF
--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -101,18 +101,18 @@ def save_config(config):
         for field in order:
             if isinstance(field, dict): # If the field is a dict, it means that it has a custom property (for example default_flow_style).
                 if field["key"] in config:
-                    yaml.dump({field["key"]: config[field["key"]]}, config_file, default_flow_style=field["default_flow_style"])
+                    yaml.dump({field["key"]: config[field["key"]]}, config_file, default_flow_style=field["default_flow_style"], allow_unicode=True)
                     # The considered fields are deleted, thus `config` at the end will contain only custom fields written by the user.
                     del config[field["key"]]
             else: # When the field is a string, it doesn't have any custom properties, so it's just a dict key.
                 if field in config:
-                    yaml.dump({field: config[field]}, config_file)
+                    yaml.dump({field: config[field]}, config_file, allow_unicode=True)
                     del config[field] # Same reason for deleting as above.
 
         if config != {}:
             print(warning("Found unknown fields in config.yml: " + ", ".join([str(x) for x in config])))
             # All remaining non-considered fields are appended to the end of the file.
-            yaml.dump(config, config_file)
+            yaml.dump(config, config_file, allow_unicode=True)
 
 
 def import_importlib_resources():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -113,3 +113,23 @@ def test_version_change(create_package):
                                        'abc3.cpp': {'points': 25, 'expected': {1: 'OK', 2: 'WA', 3: 'WA', 4: 'ML'}},
                                        'abc4.cpp': {'points': 50, 'expected': {1: 'OK', 2: 'OK', 3: 'WA', 4: 'RE'}}}
     assert old_expected_scores == util.try_fix_config(config)["sinol_expected_scores"]
+
+
+def test_saving_config_with_unicode(create_package):
+    config_path = os.path.join(create_package, "config.yml")
+    polish_title = "Zadanie ęĘóÓąĄśŚżŻźŹćĆńŃ"
+    polish_title_yaml = "title: " + polish_title
+
+    def read_config_lines():
+        with open(config_path, "r") as config_file:
+            return config_file.read().split('\n')
+
+    config_text = '\n'.join([polish_title_yaml] + read_config_lines()[1:])
+    with open(config_path, "w") as config_file:
+        config_file.write(config_text)
+
+    with open(config_path, "r") as config_file:
+        config = yaml.load(config_file, Loader=yaml.FullLoader)
+    assert config['title'] == polish_title
+    util.save_config(config)
+    assert read_config_lines()[0] == polish_title_yaml


### PR DESCRIPTION
Previously, running `save_config` would result in changing `Przykładowe zadanie` to `"Przyk\u0142adowe zadanie"`.
Apart from that function, `yaml.dump` seems to be used only for writing md5sums/filenames and in tests, so there shouldn't be a problem outside of `save_config`.

Steps to reproduce:
1. Run `sinol-make gen && sinol-make run --apply-suggestions` in the example package from this repo
2. Observe escaped unicode in config.yml