### PR TITLE
Restrict the 'push' workflow trigger to main

### DIFF
--- a/.github/workflows/Arch.yaml
+++ b/.github/workflows/Arch.yaml
@@ -1,6 +1,9 @@
 name: pytest-arch
 run-name: Run pytest on Arch Linux
-on: [push, pull_request]
+on:
+  push:
+    branches: 'main'
+  pull_request:
 jobs:
   pytest:
     runs-on: self-hosted

--- a/.github/workflows/GithubRunner.yaml
+++ b/.github/workflows/GithubRunner.yaml
@@ -1,6 +1,9 @@
 name: pytest-github-runner
 run-name: Run tests for GitHub Runner
-on: [push, pull_request]
+on:
+  push:
+    branches: 'main'
+  pull_request:
 jobs:
   pytest:
     strategy:

--- a/.github/workflows/Ubuntu.yaml
+++ b/.github/workflows/Ubuntu.yaml
@@ -1,6 +1,9 @@
 name: pytest-ubuntu
 run-name: Run pytest on Ubuntu
-on: [push, pull_request]
+on:
+  push:
+    branches: 'main'
+  pull_request:
 jobs:
   pytest:
     runs-on: self-hosted

--- a/.github/workflows/macOS.yaml
+++ b/.github/workflows/macOS.yaml
@@ -1,6 +1,9 @@
 name: pytest-macos
 run-name: Run pytest on macOS
-on: [push, pull_request]
+on:
+  push:
+    branches: 'main'
+  pull_request:
 
 jobs:
   pytest:


### PR DESCRIPTION
This is to avoid duplicate runs for PRs opened from a branch in the base repository.
One alternative would be to limit `pull_request` to PRs from outside repositories, which might be desired in the future. 