### PR TITLE
Remove fsanitize for ingen and inwer

### DIFF
--- a/src/sinol_make/commands/ingen/ingen_util.py
+++ b/src/sinol_make/commands/ingen/ingen_util.py
@@ -47,7 +47,7 @@ def get_ingen(task_id, ingen_path=None):
     return correct_ingen
 
 
-def compile_ingen(ingen_path: str, args: argparse.Namespace, compilation_flags='default'):
+def compile_ingen(ingen_path: str, args: argparse.Namespace, compilation_flags='default', use_fsanitize=False):
     """
     Compiles ingen and returns path to compiled executable.
     If ingen_path is shell script, then it will be returned.
@@ -57,7 +57,7 @@ def compile_ingen(ingen_path: str, args: argparse.Namespace, compilation_flags='
 
     compilers = compiler.verify_compilers(args, [ingen_path])
     ingen_exe, compile_log_path = compile.compile_file(ingen_path, package_util.get_executable(ingen_path),
-                                                       compilers, compilation_flags, use_fsanitize=True,
+                                                       compilers, compilation_flags, use_fsanitize=use_fsanitize,
                                                        additional_flags='-D_INGEN')
 
     if ingen_exe is None:

--- a/src/sinol_make/commands/inwer/inwer_util.py
+++ b/src/sinol_make/commands/inwer/inwer_util.py
@@ -29,13 +29,13 @@ def get_inwer_path(task_id: str, path=None) -> Union[str, None]:
         return None
 
 
-def compile_inwer(inwer_path: str, args: argparse.Namespace, compilation_flags='default'):
+def compile_inwer(inwer_path: str, args: argparse.Namespace, compilation_flags='default', use_fsanitize=False):
     """
     Compiles inwer and returns path to compiled executable and path to compile log.
     """
     compilers = compiler.verify_compilers(args, [inwer_path])
     inwer_exe, compile_log_path = compile.compile_file(inwer_path, package_util.get_executable(inwer_path), compilers,
-                                                       compilation_flags, use_fsanitize=True,
+                                                       compilation_flags, use_fsanitize=use_fsanitize,
                                                        additional_flags='-D_INWER')
 
     if inwer_exe is None:

--- a/tests/commands/gen/test_integration.py
+++ b/tests/commands/gen/test_integration.py
@@ -236,20 +236,6 @@ def test_correct_solution_changed(create_package):
         assert outputs[os.path.basename(output)] != sm_util.get_file_md5(output)
 
 
-@pytest.mark.parametrize("create_package", [util.get_shell_ingen_pack_path()], indirect=True)
-def test_fsanitize(create_package):
-    """
-    Test if ingen is compiled with -fsanitize=address,undefined flags.
-    """
-    if sm_util.is_macos_arm():
-        pytest.skip("-fsanitize=address,undefined is not supported on Apple Silicon")
-    for ingen in ["prog/geningen3.cpp", "prog/geningen4.cpp"]:
-        with pytest.raises(SystemExit) as e:
-            simple_run([ingen])
-        assert e.type == SystemExit
-        assert e.value.code == 1
-
-
 @pytest.mark.parametrize("create_package", [util.get_bad_tests_package_path()], indirect=True)
 def test_bad_tests(create_package, capsys):
     """

--- a/tests/commands/inwer/test_integration.py
+++ b/tests/commands/inwer/test_integration.py
@@ -143,20 +143,3 @@ def test_no_output(capsys, create_package):
     assert e.value.code == 0
     out = capsys.readouterr().out
     assert "No output" in out
-
-
-@pytest.mark.parametrize("create_package", [util.get_inwer_package_path()], indirect=True)
-def test_fsanitize(create_package):
-    """
-    Test if inwer is compiled with -fsanitize=address,undefined.
-    """
-    if sm_util.is_macos_arm():
-        pytest.skip("-fsanitize=address,undefined is not supported on Apple Silicon")
-    for inwer in ["prog/werinwer5.cpp", "prog/werinwer6.cpp"]:
-        parser = configure_parsers()
-        args = parser.parse_args(["inwer", inwer])
-        command = Command()
-        with pytest.raises(SystemExit) as e:
-            command.run(args)
-        assert e.type == SystemExit
-        assert e.value.code == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,10 +18,9 @@ def _compile(args):
     output = paths.get_executables_path(os.path.splitext(os.path.basename(file_path))[0] + ".e")
     compile_log_path = paths.get_compilation_log_path(os.path.basename(file_path) + ".compile_log")
     basename = os.path.basename(file_path)
-    use_fsanitize = fnmatch.fnmatch(basename, "*ingen*") or fnmatch.fnmatch(basename, "*inwer*")
     try:
         with open(compile_log_path, "w") as compile_log:
-            compile.compile(file_path, output, compile_log=compile_log, use_fsanitize=use_fsanitize)
+            compile.compile(file_path, output, compile_log=compile_log)
     except CompilationError:
         compile.print_compile_log(compile_log_path)
         raise


### PR DESCRIPTION
Some linux distros have `vm.mmap_rnd_bits` set by default to 32. This sometimes breaks address and UB sanitizers. A workaround for this is to set `sudo sysctl vm.mmap_rnd_bits = 28`, but we decided that we'd rather delete sanitizers for now. The code is not completely deleted, because in future a `verify` command will run ingen and inwer with proper warnings and those sanitizers enabled  