### PR TITLE
Aliases for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,15 @@ You can also run multiple commands at once, for example:
 sinol-make gen prog/abcingen2.cpp inwer --cpus 4 run --tests abc1*.in doc export --no-statement
 ```
 
+There are also available short aliases for the commands:
+- `sinol-make r` for `sinol-make run`
+- `sinol-make g` for `sinol-make gen`
+- `sinol-make i` for `sinol-make inwer`
+- `sinol-make e` for `sinol-make export`
+- `sinol-make d` for `sinol-make doc`
+- `sinol-make v` for `sinol-make verify`
+- `sm` for `sinol-make`
+
 ### Reporting bugs and contributing code
 
 - Want to report a bug or request a feature? [Open an issue](https://github.com/sio2project/sinol-make/issues).

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ tests =
 [options.entry_points]
 console_scripts =
     sinol-make = sinol_make:main
+    sm = sinol_make:main
 
 [tool:pytest]
 testpaths =

--- a/src/sinol_make/__init__.py
+++ b/src/sinol_make/__init__.py
@@ -53,11 +53,16 @@ def main_exn():
     curr_args = []
     commands = util.get_commands()
     commands_dict = {command.get_name(): command for command in commands}
+    commands_short_dict = {command.get_short_name(): command for command in commands if command.get_short_name()}
     for arg in sys.argv[1:]:
         if arg in commands_dict.keys() and not (len(curr_args) > 0 and curr_args[0] == 'init'):
             if curr_args:
                 arguments.append(curr_args)
             curr_args = [arg]
+        elif arg in commands_short_dict.keys() and not (len(curr_args) > 0 and curr_args[0] == 'init'):
+            if curr_args:
+                arguments.append(curr_args)
+            curr_args = [commands_short_dict[arg].get_name()]
         else:
             curr_args.append(arg)
     if curr_args:

--- a/src/sinol_make/commands/doc/__init__.py
+++ b/src/sinol_make/commands/doc/__init__.py
@@ -17,6 +17,9 @@ class Command(BaseCommand):
     def get_name(self):
         return "doc"
 
+    def get_short_name(self):
+        return "d"
+
     def compile_file_latex_div(self, file_path):
         print(f'Compiling {os.path.basename(file_path)} (latex to dvi)...')
         os.chdir(os.path.dirname(file_path))

--- a/src/sinol_make/commands/export/__init__.py
+++ b/src/sinol_make/commands/export/__init__.py
@@ -23,6 +23,9 @@ class Command(BaseCommand):
     def get_name(self):
         return "export"
 
+    def get_short_name(self):
+        return "e"
+
     def configure_subparser(self, subparser: argparse.ArgumentParser):
         parser = subparser.add_parser(
             self.get_name(),

--- a/src/sinol_make/commands/gen/__init__.py
+++ b/src/sinol_make/commands/gen/__init__.py
@@ -15,6 +15,9 @@ class Command(BaseCommand):
     def get_name(self):
         return "gen"
 
+    def get_short_name(self):
+        return "g"
+
     def configure_subparser(self, subparser):
         parser = subparser.add_parser(
             self.get_name(),

--- a/src/sinol_make/commands/inwer/__init__.py
+++ b/src/sinol_make/commands/inwer/__init__.py
@@ -23,6 +23,9 @@ class Command(BaseCommand):
     def get_name(self):
         return "inwer"
 
+    def get_short_name(self):
+        return "i"
+
     def configure_subparser(self, subparser: argparse.ArgumentParser):
         parser = subparser.add_parser(
             self.get_name(),

--- a/src/sinol_make/commands/run/__init__.py
+++ b/src/sinol_make/commands/run/__init__.py
@@ -272,6 +272,8 @@ class Command(BaseCommand):
     def get_name(self):
         return 'run'
 
+    def get_short_name(self):
+        return 'r'
 
     def configure_subparser(self, subparser):
         parser = subparser.add_parser(

--- a/src/sinol_make/commands/verify/__init__.py
+++ b/src/sinol_make/commands/verify/__init__.py
@@ -21,6 +21,9 @@ class Command(BaseCommand):
     def get_name(self):
         return "verify"
 
+    def get_short_name(self):
+        return "v"
+
     def configure_subparser(self, subparser):
         parser = subparser.add_parser(
             self.get_name(),

--- a/src/sinol_make/interfaces/BaseCommand.py
+++ b/src/sinol_make/interfaces/BaseCommand.py
@@ -11,6 +11,13 @@ class BaseCommand:
         pass
 
 
+    def get_short_name(self):
+        """
+        Get short name of command
+        """
+        return None
+
+
     def configure_subparser(self, subparser):
         """
         Configure subparser for command


### PR DESCRIPTION
Introduces these aliases:
- `sinol-make r` for `sinol-make run`
- `sinol-make g` for `sinol-make gen`
- `sinol-make i` for `sinol-make inwer`
- `sinol-make e` for `sinol-make export`
- `sinol-make d` for `sinol-make doc`
- `sinol-make v` for `sinol-make verify`
- `sm` for `sinol-make`
