### PR TITLE
Bump Python versions

### DIFF
--- a/.github/workflows/Arch.yaml
+++ b/.github/workflows/Arch.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: self-hosted
     strategy:
         matrix:
-            python-version: ["3.8", "3.12"]
+            python-version: ["3.9", "3.13"]
     name: pytest-arch-python-${{ matrix.python-version }}
     container:
       image: archlinux:latest

--- a/.github/workflows/Arch.yaml
+++ b/.github/workflows/Arch.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: self-hosted
     strategy:
         matrix:
-            python-version: ["3.9", "3.13"]
+            python-version: ["3.9", "3.13.1"]
     name: pytest-arch-python-${{ matrix.python-version }}
     container:
       image: archlinux:latest

--- a/.github/workflows/GithubRunner.yaml
+++ b/.github/workflows/GithubRunner.yaml
@@ -8,7 +8,7 @@ jobs:
   pytest:
     strategy:
         matrix:
-            python-version: ["3.8", "3.12"]
+            python-version: ["3.9", "3.13"]
     name: pytest-github-runner-python-${{ matrix.python-version }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/Ubuntu.yaml
+++ b/.github/workflows/Ubuntu.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: self-hosted
     strategy:
         matrix:
-            python-version: ["3.8", "3.12"]
+            python-version: ["3.9", "3.13"]
     name: pytest-ubuntu-python-${{ matrix.python-version }}
     container:
       image: ubuntu:latest

--- a/.github/workflows/macOS.yaml
+++ b/.github/workflows/macOS.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     strategy:
         matrix:
-            python-version: ["3.10", "3.12"]
+            python-version: ["3.10", "3.13"]
     name: pytest-macos-python-${{ matrix.python-version }}
     steps:
       - name: Checkout

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 packages = find_namespace:
 packages_dir = src
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.9
 install_requires =
     argparse
     argcomplete


### PR DESCRIPTION
Bumped minimum version to 3.9 (3.8 has reached end-of-life) and changed from 3.12 to 3.13 in tests