### PR TITLE
Run sio2jail self-check with Sio2jailExecutor

### DIFF
--- a/src/sinol_make/__init__.py
+++ b/src/sinol_make/__init__.py
@@ -12,7 +12,7 @@ from sinol_make.task_type.normal import NormalTaskType # noqa
 from sinol_make.task_type.interactive import InteractiveTaskType # noqa
 
 
-__version__ = "1.9.2"
+__version__ = "1.9.4"
 
 
 def configure_parsers():

--- a/src/sinol_make/__init__.py
+++ b/src/sinol_make/__init__.py
@@ -12,7 +12,7 @@ from sinol_make.task_type.normal import NormalTaskType # noqa
 from sinol_make.task_type.interactive import InteractiveTaskType # noqa
 
 
-__version__ = "1.9.3"
+__version__ = "1.9.2"
 
 
 def configure_parsers():
@@ -38,7 +38,7 @@ def configure_parsers():
 
 
 def check_sio2jail():
-    if util.is_linux() and not sio2jail.check_sio2jail():
+    if sio2jail.sio2jail_supported() and not sio2jail.check_sio2jail():
         print(util.warning('Up to date `sio2jail` in `~/.local/bin/` not found, installing new version...'))
         try:
             if sio2jail.install_sio2jail():

--- a/src/sinol_make/commands/run/__init__.py
+++ b/src/sinol_make/commands/run/__init__.py
@@ -280,7 +280,7 @@ class Command(BaseCommand):
                 After running the solutions, it compares the solutions\' scores with the ones saved in config.yml.'
         )
 
-        default_timetool = 'sio2jail' if util.is_linux() else 'time'
+        default_timetool = 'sio2jail' if sio2jail.sio2jail_supported() else 'time'
 
         parser.add_argument('-s', '--solutions', type=str, nargs='+',
                             help='solutions to be run, for example prog/abc{b,s}*.{cpp,py}')
@@ -764,7 +764,7 @@ class Command(BaseCommand):
 
         def use_sio2jail():
             timetool_path = None
-            if not util.is_linux():
+            if not sio2jail.sio2jail_supported():
                 util.exit_with_error('As `sio2jail` works only on Linux-based operating systems,\n'
                                      'we do not recommend using operating systems such as macOS.\n'
                                      'Nevertheless, you can still run sinol-make by specifying\n'
@@ -789,12 +789,12 @@ class Command(BaseCommand):
 
         timetool_path, timetool_name = None, None
         preferred_timetool = self.contest.preferred_timetool()
-        if preferred_timetool == 'sio2jail' and util.is_linux():
+        if preferred_timetool == 'sio2jail' and sio2jail.sio2jail_supported():
             use_default_timetool = use_sio2jail
         elif preferred_timetool == 'time':
             use_default_timetool = use_time
         else:
-            use_default_timetool = use_sio2jail if util.is_linux() else use_time
+            use_default_timetool = use_sio2jail if sio2jail.sio2jail_supported() else use_time
 
         if args.time_tool is None and self.config.get('sinol_undocumented_time_tool', '') != '':
             if self.config.get('sinol_undocumented_time_tool', '') == 'sio2jail':

--- a/src/sinol_make/executors/__init__.py
+++ b/src/sinol_make/executors/__init__.py
@@ -45,10 +45,12 @@ class BaseExecutor:
         """
 
         command = self._wrap_command(command, result_file_path, time_limit, memory_limit)
-        tle, mle, return_code, proc_stderr = self._execute(command, time_limit, hard_time_limit, memory_limit,
+        cmdline = " ".join(command)
+        tle, mle, return_code, proc_stderr = self._execute(cmdline, time_limit, hard_time_limit, memory_limit,
                                                            result_file_path, executable, execution_dir, stdin, stdout,
                                                            stderr, fds_to_close, *args, **kwargs)
         result = self._parse_result(tle, mle, return_code, result_file_path)
+        result.Cmdline = cmdline
         if not result.Stderr:
             result.Stderr = proc_stderr
         if tle:

--- a/src/sinol_make/executors/detailed.py
+++ b/src/sinol_make/executors/detailed.py
@@ -17,7 +17,7 @@ class DetailedExecutor(BaseExecutor):
     def _wrap_command(self, command: List[str], result_file_path: str, time_limit: int, memory_limit: int) -> List[str]:
         return command
 
-    def _execute(self, command: List[str], time_limit: int, hard_time_limit: int, memory_limit: int,
+    def _execute(self, cmdline: str, time_limit: int, hard_time_limit: int, memory_limit: int,
                  result_file_path: str, executable: str, execution_dir: str, stdin: int, stdout: int,
                  stderr: Union[None, int], fds_to_close: Union[None, List[int]],
                  *args, **kwargs) -> Tuple[bool, bool, int, List[str]]:
@@ -25,7 +25,7 @@ class DetailedExecutor(BaseExecutor):
         mem_used = 0
         if stderr is None:
             stderr = subprocess.PIPE
-        process = subprocess.Popen(" ".join(command), shell=True, *args, stdin=stdin, stdout=stdout, stderr=stderr,
+        process = subprocess.Popen(cmdline, shell=True, *args, stdin=stdin, stdout=stdout, stderr=stderr,
                                    preexec_fn=os.setpgrp, cwd=execution_dir, **kwargs)
         if fds_to_close is not None:
             for fd in fds_to_close:

--- a/src/sinol_make/executors/time.py
+++ b/src/sinol_make/executors/time.py
@@ -22,7 +22,7 @@ class TimeExecutor(BaseExecutor):
 
         return [f'{time_name}', '-f', '"%U\\n%M\\n%x"', '-o', result_file_path] + command
 
-    def _execute(self, command: List[str], time_limit: int, hard_time_limit: int, memory_limit: int,
+    def _execute(self, cmdline: str, time_limit: int, hard_time_limit: int, memory_limit: int,
                  result_file_path: str, executable: str, execution_dir: str, stdin: int, stdout: int,
                  stderr: Union[None, int], fds_to_close: Union[None, List[int]],
                  *args, **kwargs) -> Tuple[bool, bool, int, List[str]]:
@@ -30,7 +30,7 @@ class TimeExecutor(BaseExecutor):
         mem_limit_exceeded = False
         if stderr is None:
             stderr = subprocess.PIPE
-        process = subprocess.Popen(" ".join(command), shell=True, *args, stdin=stdin, stdout=stdout, stderr=stderr,
+        process = subprocess.Popen(cmdline, shell=True, *args, stdin=stdin, stdout=stdout, stderr=stderr,
                                    preexec_fn=os.setpgrp, cwd=execution_dir, **kwargs)
         if fds_to_close is not None:
             for fd in fds_to_close:

--- a/src/sinol_make/sio2jail/__init__.py
+++ b/src/sinol_make/sio2jail/__init__.py
@@ -7,7 +7,8 @@ import tempfile
 import requests
 
 from sinol_make import util
-
+from sinol_make.executors.sio2jail import Sio2jailExecutor
+from sinol_make.structs.status_structs import Status
 
 def sio2jail_supported():
     return util.is_linux()
@@ -82,35 +83,66 @@ def check_perf_counters_enabled():
     with open('/proc/sys/kernel/perf_event_paranoid') as f:
         perf_event_paranoid = int(f.read())
 
-    sio2jail = get_default_sio2jail_path()
+    executor = Sio2jailExecutor(get_default_sio2jail_path())
     test_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'perf_test.py')
     python_executable = sys.executable
+    command = [python_executable, test_file]
+    time_limit = 1000
+    memory_limit = 65536
 
-    # subprocess.Pipe is not used, because than the code would hang on process.communicate()
-    with tempfile.TemporaryFile() as tmpfile:
-        process = subprocess.Popen([sio2jail, '--mount-namespace', 'off', '--', python_executable, test_file],
-                                   stdout=tmpfile, stderr=subprocess.DEVNULL)
-        process.wait()
-        tmpfile.seek(0)
-        output = tmpfile.read().decode('utf-8')
-        process.terminate()
+    with (
+        tempfile.NamedTemporaryFile() as sio2jail_result,
+        tempfile.TemporaryFile() as command_stdout,
+        tempfile.TemporaryFile() as command_stderr
+    ):
+        result = executor.execute(
+            command=command,
+            time_limit=time_limit,
+            hard_time_limit=None,
+            memory_limit=memory_limit,
+            result_file_path=sio2jail_result.name,
+            executable=None,
+            execution_dir=None,
+            stdout=command_stdout,
+            stderr=command_stderr)
+        command_stdout.seek(0)
+        output_str = command_stdout.read().decode('utf-8')
+        command_stderr.seek(0)
+        error_str = command_stderr.read().decode('utf-8')
+        sio2jail_result.seek(0)
+        result_raw = sio2jail_result.read().decode('utf-8')
 
-    if output != "Test string\n":
+    expected_output = "Test Successful!\n"
+    if result.Status != Status.OK or output_str != expected_output or error_str:
         max_perf_event_paranoid = 2
         if perf_event_paranoid > max_perf_event_paranoid:
-            hint = (f"You have `kernel.perf_event_paranoid` set to `{perf_event_paranoid}`"
-                ", which might be preventing userspace perf counters from working.\n"
-                f"Try running: `sudo sysctl kernel.perf_event_paranoid={max_perf_event_paranoid}`\n"
-                "If that fixes the problem, you can set this permanently by adding "
-                f"`kernel.perf_event_paranoid={max_perf_event_paranoid}` to `/etc/sysctl.conf` and rebooting.\n")
+            hint = (f"You have sysctl kernel.perf_event_paranoid = {perf_event_paranoid}"
+                "\nThis might restrict access to instruction counting."
+                "\nTry relaxing this setting by running:"
+                f"\n\tsudo sysctl kernel.perf_event_paranoid={max_perf_event_paranoid}"
+                "\nIf that fixes the problem, you can set this permanently by adding:"
+                f"\n\tkernel.perf_event_paranoid={max_perf_event_paranoid}"
+                "\nto /etc/sysctl.conf and rebooting."
+            )
         else:
-            hint = ("Your kernel, drivers, or hardware might be too old.\n"
-                "Check if the Intel PMU driver is loaded: `dmesg | grep -i 'perf'`\n"
-                "You can also check if the perf tool works correctly: `perf stat -e instructions:u -- sleep 0`\n"
-                "(if perf can't be found, it might be located in: `/usr/lib/linux-tools/*/perf`).\n")
-        cmdline = " ".join(process.args)
-        util.exit_with_error(f"Failed performance counters test: `{cmdline}`\n"
-            + hint +
-            "Alternatively, you can run sinol-make without instruction counting"
-            ", by adding the `--time-tool time` flag.\n"
-            "For more details, see https://github.com/sio2project/sio2jail#running.\n")
+            hint = ("Your kernel, drivers, or hardware might be unsupported."
+                "\nDiagnose this further by trying the following commands:"
+                "\n1. Check if the `perf` tool is able to read performance counters correctly:"
+                "\n\tperf stat -e instructions:u -- sleep 0"
+                "\nIf `perf` can't be found, it might be located in: /usr/lib/linux-tools/*/perf"
+                "\n2. Check if the Performance Monitoring Unit driver was successfully loaded:"
+                "\n\tdmesg | grep PMU"
+            )
+        opt_stdout_hint = f"\nCommand stdout (expected {repr(expected_output)}):\n---\n{output_str}" if output_str != expected_output else ""
+        opt_stderr_hint = f"\nCommand stderr (expected none):\n---\n{error_str}" if error_str else ""
+        opt_sio2jail_hint = f"\nsio2jail result:\n---\n{result_raw}" if result.Status != Status.OK else ""
+        util.exit_with_error("Failed sio2jail instruction counting test!"
+            f"\n\nTest command:\n---\n{result.Cmdline}\n"
+            f"{opt_stdout_hint}"
+            f"{opt_stderr_hint}"
+            f"{opt_sio2jail_hint}"
+            f"\n\n{hint}"
+            "\n\nYou can also disable instruction counting by adding the `--time-tool time` flag."
+            "\nThis will make measured solution run times significantly different from SIO2."
+            "\nFor more details, see https://github.com/sio2project/sio2jail#running."
+        )

--- a/src/sinol_make/sio2jail/__init__.py
+++ b/src/sinol_make/sio2jail/__init__.py
@@ -136,7 +136,7 @@ def check_perf_counters_enabled():
         opt_stdout_hint = f"\nCommand stdout (expected {repr(expected_output)}):\n---\n{output_str}" if output_str != expected_output else ""
         opt_stderr_hint = f"\nCommand stderr (expected none):\n---\n{error_str}" if error_str else ""
         opt_sio2jail_hint = f"\nsio2jail result:\n---\n{result_raw}" if result.Status != Status.OK else ""
-        util.exit_with_error("Failed sio2jail instruction counting test!"
+        util.exit_with_error("Failed sio2jail instruction counting self-check!"
             f"\n\nTest command:\n---\n{result.Cmdline}\n"
             f"{opt_stdout_hint}"
             f"{opt_stderr_hint}"

--- a/src/sinol_make/sio2jail/perf_test.py
+++ b/src/sinol_make/sio2jail/perf_test.py
@@ -1,1 +1,1 @@
-print("Test string")
+print("Test Successful!")

--- a/src/sinol_make/structs/status_structs.py
+++ b/src/sinol_make/structs/status_structs.py
@@ -97,9 +97,11 @@ class ExecutionResult:
     Comment: str
     # Stderr of the program (used for checkers/interactors)
     Stderr: List[str]
+    # Original command line that was run
+    Cmdline: str
 
     def __init__(self, status=None, Time=None, Memory=None, Points=0, Error=None, Fail=False, ExitSignal=0, Comment="",
-                 Stderr=None):
+                 Stderr=None, Cmdline=None):
         self.Status = status
         self.Time = Time
         self.Memory = Memory
@@ -109,6 +111,7 @@ class ExecutionResult:
         self.ExitSignal = ExitSignal
         self.Comment = Comment
         self.Stderr = Stderr if Stderr is not None else []
+        self.Cmdline = Cmdline
 
     @staticmethod
     def from_dict(dict):
@@ -122,6 +125,7 @@ class ExecutionResult:
             ExitSignal=dict.get("ExitSignal", 0),
             Comment=dict.get("Comment", ""),
             Stderr=dict.get("Stderr", []),
+            Cmdline=dict.get("Cmdline", ""),
         )
 
     def to_dict(self):
@@ -135,4 +139,5 @@ class ExecutionResult:
             "ExitSignal": self.ExitSignal,
             "Comment": self.Comment,
             "Stderr": self.Stderr,
+            "Cmdline": self.Cmdline,
         }

--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -312,9 +312,9 @@ def is_wsl():
 
 def is_linux():
     """
-    Function to check if the program is running on Linux and not WSL.
+    Function to check if the program is running on Linux (including WSL).
     """
-    return sys.platform == "linux" and not is_wsl()
+    return sys.platform == "linux"
 
 
 def is_macos():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import fnmatch
 import multiprocessing as mp
 
-from sinol_make import util
+from sinol_make import sio2jail, util
 from sinol_make.helpers import compile, paths, cache, oicompare
 from sinol_make.interfaces.Errors import CompilationError
 
@@ -99,7 +99,7 @@ def pytest_generate_tests(metafunc):
         time_tools = []
         if metafunc.config.getoption("time_tool") != []:
             time_tools = metafunc.config.getoption("time_tool")
-        elif util.is_linux():
+        elif sio2jail.sio2jail_supported():
             time_tools = ["sio2jail", "time"]
         else:
             time_tools = ["time"]
@@ -118,6 +118,6 @@ def pytest_collection_modifyitems(config, items: List[pytest.Item]):
 
     for item in items:
         if "sio2jail" in item.keywords:
-            if not util.is_linux() or config.getoption("--time-tool") == ["time"] or \
+            if not sio2jail.sio2jail_supported() or config.getoption("--time-tool") == ["time"] or \
                     config.getoption("--github-runner"):
                 item.add_marker(pytest.mark.skip(reason="sio2jail required"))

--- a/tests/test_sio2jail.py
+++ b/tests/test_sio2jail.py
@@ -9,7 +9,7 @@ from sinol_make import sio2jail, util
 
 @pytest.mark.github_runner
 def test_install_sio2jail():
-    if sys.platform != 'linux':
+    if not sio2jail.sio2jail_supported():
         return
 
     try:
@@ -34,7 +34,7 @@ def test_install_sio2jail():
 
 @pytest.mark.github_runner
 def test_check_sio2jail():
-    if sys.platform != 'linux':
+    if not sio2jail.sio2jail_supported():
         return
 
     try:
@@ -59,7 +59,7 @@ def test_perf_counters_not_set():
     """
     Test `sio2jail.check_perf_counters_enabled` with perf counters disabled
     """
-    if sys.platform != 'linux':
+    if not sio2jail.sio2jail_supported():
         return
 
     sio2jail.install_sio2jail()
@@ -72,7 +72,7 @@ def test_perf_counters_set():
     """
     Test `sio2jail.check_perf_counters_enabled` with perf counters enabled
     """
-    if not util.is_linux():
+    if not sio2jail.sio2jail_supported():
         return
     sio2jail.check_perf_counters_enabled()
 
@@ -82,7 +82,7 @@ def test_updating():
     """
     Test updating sio2jail
     """
-    if sys.platform != 'linux':
+    if not sio2jail.sio2jail_supported():
         return
     try:
         os.remove(os.path.expanduser('~/.local/bin/oiejq'))


### PR DESCRIPTION
We currently don't pass enough cmdline arguments to sio2jail self-check,
which makes it fail erroneously on some system configurations.
This change prevents that from happening, by using Sio2jailExecutor to
run the self check.

Notably this change required adding the original cmdline to
ExecutionResult for logging errors later - this feels like a leaky
abstraction, but that class actually already carries the process exit
signal and stderr.

Also improved sio2jail related error messages for better user experience.