### PR TITLE
Document sinol_total_score

### DIFF
--- a/src/sinol_make/util.py
+++ b/src/sinol_make/util.py
@@ -101,6 +101,7 @@ def save_config(config):
         "time_limit",
         "time_limits",
         "override_limits",
+        "sinol_total_score",
         "scores",
         {
             "key": "extra_compilation_files",


### PR DESCRIPTION
Followup to #310 for more sane `config.yml` field ordering and to stop the `unknown fields` warning in the `save_config` function.