### PR TITLE
Invalidate compilation cache when extra compilation args or files change

### DIFF
--- a/example_package/config.yml
+++ b/example_package/config.yml
@@ -58,6 +58,9 @@ override_limits:
 
 # extra_compilation_files: ['__ID__lib.cpp', '__ID__lib.py']
 
+# Changing `extra_compilation_args` or the contents of any of the `extra_compilation_files`
+# invalidates the compilation cache, so everything using them is compiled again.
+
 # Alternative interactor used for running test runs in interactive via IO tasks. Not required. If not provided and
 # the task is interactive via IO (and has test runs configured), then the default interactor will be used.
 testrun_soc: __ID__soc_testrun.soc

--- a/src/sinol_make/commands/run/__init__.py
+++ b/src/sinol_make/commands/run/__init__.py
@@ -347,19 +347,9 @@ class Command(BaseCommand):
         extra_compilation_args = []
         extra_compilation_files = []
         if use_extras:
-            lang = os.path.splitext(source_file)[1][1:]
-            args = self.config.get("extra_compilation_args", {}).get(lang, [])
-            if isinstance(args, str):
-                args = [args]
-            for arg in args:
-                path = os.path.join(os.getcwd(), "prog", arg)
-                if os.path.exists(path):
-                    extra_compilation_args.append(path)
-                else:
-                    extra_compilation_args.append(arg)
-
-            for file in self.config.get("extra_compilation_files", []):
-                extra_compilation_files.append(os.path.join(os.getcwd(), "prog", file))
+            lang = package_util.get_file_lang(source_file)
+            extra_compilation_args = package_util.get_extra_compilation_args(lang, self.config)
+            extra_compilation_files = package_util.get_extra_compilation_files(self.config)
 
         try:
             with open(compile_log_file, "w") as compile_log:
@@ -958,7 +948,6 @@ class Command(BaseCommand):
         title = self.config["title"]
         print("Task: %s (tag: %s)" % (title, self.ID))
         self.cpus = args.cpus or util.default_cpu_count()
-        cache.process_extra_compilation_files(self.config.get("extra_compilation_files", []), self.ID)
         cache.process_extra_execution_files(self.config.get("extra_execution_files", {}), self.ID)
         cache.remove_results_if_contest_type_changed(self.config.get("sinol_contest_type", "default"))
 

--- a/src/sinol_make/helpers/cache.py
+++ b/src/sinol_make/helpers/cache.py
@@ -39,16 +39,22 @@ def get_cache_file(solution_path: str) -> CacheFile:
         return CacheFile()
 
 
-def check_compiled(file_path: str, compilation_flags: str, sanitizers: str) -> Union[str, None]:
+def check_compiled(file_path: str, compilation_flags: str, sanitizers: str,
+                   extra_compilation_hash: str = "") -> Union[str, None]:
     """
     Check if a file is compiled
     :param file_path: Path to the file
+    :param compilation_flags: Group of compilation flags used
+    :param sanitizers: What sanitizers were used for compilation (if any).
+    :param extra_compilation_hash: Hash of extra compilation arguments and files
+                                   (as returned by `package_util.get_extra_compilation_hash`).
     :return: executable path if compiled, None otherwise
     """
     md5sum = util.get_file_md5(file_path)
     try:
         info = get_cache_file(file_path)
-        if info.md5sum == md5sum and info.compilation_flags == compilation_flags and info.sanitizers == sanitizers:
+        if info.md5sum == md5sum and info.compilation_flags == compilation_flags and \
+                info.sanitizers == sanitizers and info.extra_compilation_hash == extra_compilation_hash:
             exe_path = info.executable_path
             if os.path.exists(exe_path):
                 return exe_path
@@ -57,7 +63,8 @@ def check_compiled(file_path: str, compilation_flags: str, sanitizers: str) -> U
         return None
 
 
-def save_compiled(file_path: str, exe_path: str, compilation_flags: str, sanitizers: str, clear_cache: bool = False):
+def save_compiled(file_path: str, exe_path: str, compilation_flags: str, sanitizers: str,
+                  extra_compilation_hash: str = "", clear_cache: bool = False):
     """
     Save the compiled executable path to cache in `.cache/md5sums/<basename of file_path>`,
     which contains the md5sum of the file and the path to the executable.
@@ -65,9 +72,11 @@ def save_compiled(file_path: str, exe_path: str, compilation_flags: str, sanitiz
     :param exe_path: Path to the compiled executable
     :param compilation_flags: Compilation flags used
     :param sanitizers: What sanitizers were used for compilation (if any).
+    :param extra_compilation_hash: Hash of extra compilation arguments and files
+                                   (as returned by `package_util.get_extra_compilation_hash`).
     :param clear_cache: Set to True if you want to delete all cached test results.
     """
-    info = CacheFile(util.get_file_md5(file_path), exe_path, compilation_flags, sanitizers)
+    info = CacheFile(util.get_file_md5(file_path), exe_path, compilation_flags, sanitizers, extra_compilation_hash)
     info.save(file_path)
     if clear_cache:
         remove_results_cache()
@@ -87,24 +96,6 @@ def _check_file_changed(file_path, lang, task_id):
 
     info.md5sum = md5sum
     info.save(file_path)
-
-
-def process_extra_compilation_files(extra_compilation_files, task_id):
-    """
-    Checks if extra compilation files have changed and saves them to cache.
-    If they have, removes all cached solutions that use them.
-    :param extra_compilation_files: List of extra compilation files
-    :param task_id: Task id
-    """
-    for file in extra_compilation_files:
-        file_path = os.path.join(os.getcwd(), "prog", file)
-        if not os.path.exists(file_path):
-            continue
-        md5sum = util.get_file_md5(file_path)
-        lang = package_util.get_file_lang(file)
-        if lang == 'h':
-            lang = 'cpp'
-        _check_file_changed(file_path, lang, task_id)
 
 
 def process_extra_execution_files(extra_execution_files, task_id):
@@ -155,15 +146,19 @@ def check_can_access_cache():
                              "`sinol-make` needs to be able to write to this directory.")
 
 
-def has_file_changed(file_path: str) -> bool:
+def has_file_changed(file_path: str, extra_compilation_hash: Union[str, None] = None) -> bool:
     """
     Checks if file has changed since last compilation.
     :param file_path: Path to the file
+    :param extra_compilation_hash: If set, the file is also considered changed when it was
+                                   compiled with different extra compilation arguments or files.
     :return: True if file has changed, False otherwise
     """
     try:
         info = get_cache_file(file_path)
-        return info.md5sum != util.get_file_md5(file_path)
+        if info.md5sum != util.get_file_md5(file_path):
+            return True
+        return extra_compilation_hash is not None and info.extra_compilation_hash != extra_compilation_hash
     except FileNotFoundError:
         return True
 
@@ -178,7 +173,14 @@ def check_correct_solution(task_id: str):
     except FileNotFoundError:
         return
 
-    if has_file_changed(solution) and os.path.exists(os.path.join(os.getcwd(), 'in', '.md5sums')):
+    config = package_util.get_config()
+    lang = package_util.get_file_lang(solution)
+    extra_compilation_hash = package_util.get_extra_compilation_hash(
+        lang, package_util.get_extra_compilation_args(lang, config),
+        package_util.get_extra_compilation_files(config))
+
+    if has_file_changed(solution, extra_compilation_hash) and \
+            os.path.exists(os.path.join(os.getcwd(), 'in', '.md5sums')):
         os.unlink(os.path.join(os.getcwd(), 'in', '.md5sums'))
 
 

--- a/src/sinol_make/helpers/compile.py
+++ b/src/sinol_make/helpers/compile.py
@@ -7,8 +7,8 @@ import subprocess
 
 import sinol_make.helpers.compiler as compiler
 from sinol_make import util
-from sinol_make.helpers import paths
-from sinol_make.helpers.cache import check_compiled, save_compiled, package_util
+from sinol_make.helpers import paths, package_util
+from sinol_make.helpers.cache import check_compiled, save_compiled
 from sinol_make.interfaces.Errors import CompilationError
 from sinol_make.structs.compiler_structs import Compilers
 
@@ -47,7 +47,16 @@ def compile(program, output, compilers: Compilers = None, compile_log=None, comp
     if extra_compilation_files is None:
         extra_compilation_files = []
 
-    compiled_exe = check_compiled(program, compilation_flags, use_sanitizers)
+    # Extra compilation files are copied even when the executable is cached, so that
+    # the executables directory always contains their current versions.
+    for file in extra_compilation_files:
+        dest = os.path.join(os.path.dirname(output), os.path.basename(file))
+        if not os.path.exists(dest) or util.get_file_md5(dest) != util.get_file_md5(file):
+            shutil.copy(file, dest)
+
+    extra_compilation_hash = package_util.get_extra_compilation_hash(
+        package_util.get_file_lang(program), extra_compilation_args, extra_compilation_files)
+    compiled_exe = check_compiled(program, compilation_flags, use_sanitizers, extra_compilation_hash)
     if compiled_exe is not None:
         if compile_log is not None:
             compile_log.write(f'Using cached executable {compiled_exe}\n')
@@ -55,9 +64,6 @@ def compile(program, output, compilers: Compilers = None, compile_log=None, comp
         if os.path.abspath(compiled_exe) != os.path.abspath(output):
             shutil.copy(compiled_exe, output)
         return True
-
-    for file in extra_compilation_files:
-        shutil.copy(file, os.path.join(os.path.dirname(output), os.path.basename(file)))
 
     gcc_compilation_flags = ''
     if compilation_flags == 'weak':
@@ -126,7 +132,7 @@ def compile(program, output, compilers: Compilers = None, compile_log=None, comp
     if process.returncode != 0:
         raise CompilationError('Compilation failed')
     else:
-        save_compiled(program, output, compilation_flags, use_sanitizers, clear_cache)
+        save_compiled(program, output, compilation_flags, use_sanitizers, extra_compilation_hash, clear_cache)
         return True
 
 
@@ -149,19 +155,9 @@ def compile_file(file_path: str, name: str, compilers: Compilers, compilation_fl
     extra_compilation_args = []
     extra_compilation_files = []
     if use_extras:
-        lang = os.path.splitext(file_path)[1][1:]
-        args = config.get("extra_compilation_args", {}).get(lang, [])
-        if isinstance(args, str):
-            args = [args]
-        for arg in args:
-            path = os.path.join(os.getcwd(), "prog", arg)
-            if os.path.exists(path):
-                extra_compilation_args.append(path)
-            else:
-                extra_compilation_args.append(arg)
-
-        for file in config.get("extra_compilation_files", []):
-            extra_compilation_files.append(os.path.join(os.getcwd(), "prog", file))
+        lang = package_util.get_file_lang(file_path)
+        extra_compilation_args = package_util.get_extra_compilation_args(lang, config)
+        extra_compilation_files = package_util.get_extra_compilation_files(config)
     if additional_flags is not None:
         extra_compilation_args.append(additional_flags)
 

--- a/src/sinol_make/helpers/package_util.py
+++ b/src/sinol_make/helpers/package_util.py
@@ -3,6 +3,7 @@ import re
 import yaml
 import glob
 import fnmatch
+import hashlib
 import multiprocessing as mp
 from enum import Enum
 from typing import List, Union, Dict, Any, Tuple, Type
@@ -61,6 +62,82 @@ def get_config():
         util.exit_with_error("You are not in a package directory (couldn't find config.yml in current directory).")
     except yaml.YAMLError as e:
         util.exit_with_error("config.yml is not a valid YAML. Fix it before continuing:\n" + str(e))
+
+
+def get_extra_compilation_args(lang: str, config=None) -> List[str]:
+    """
+    Returns extra compilation arguments for given language.
+    Arguments which are files in `prog/` are converted to absolute paths,
+    the rest is passed to the compiler as-is.
+    :param lang: Language (file extension without the dot), for example `cpp`.
+    :param config: Config dict. If None, it is read from `config.yml`.
+    """
+    if config is None:
+        config = get_config()
+    args = config.get("extra_compilation_args", {}).get(lang, [])
+    if isinstance(args, str):
+        args = [args]
+
+    extra_compilation_args = []
+    for arg in args:
+        path = os.path.join(os.getcwd(), "prog", arg)
+        if os.path.exists(path):
+            extra_compilation_args.append(path)
+        else:
+            extra_compilation_args.append(arg)
+    return extra_compilation_args
+
+
+def get_extra_compilation_files(config=None) -> List[str]:
+    """
+    Returns absolute paths to extra compilation files.
+    :param config: Config dict. If None, it is read from `config.yml`.
+    """
+    if config is None:
+        config = get_config()
+    return [os.path.join(os.getcwd(), "prog", file) for file in config.get("extra_compilation_files", [])]
+
+
+# Languages which are compiled together, so that a change to any of them affects
+# compilation of the others (for example a header file used by a C++ solution).
+COMPILATION_LANG_FAMILIES = {'c': 'cpp', 'cc': 'cpp', 'cpp': 'cpp', 'h': 'cpp', 'hpp': 'cpp'}
+
+
+def get_extra_compilation_hash(lang: str, extra_compilation_args=None, extra_compilation_files=None) -> str:
+    """
+    Returns a hash of everything that affects compilation apart from the compiled file itself:
+    extra compilation arguments and contents of extra compilation files.
+    Thanks to this, changing a library or a compilation flag invalidates the compilation cache.
+    :param lang: Language of the compiled file (file extension without the dot), for example `cpp`.
+                 Extra compilation files in other languages are ignored.
+    :param extra_compilation_args: Extra compilation arguments (as returned by `get_extra_compilation_args`).
+    :param extra_compilation_files: Extra compilation files (as returned by `get_extra_compilation_files`).
+    :return: Hash of the arguments and files or an empty string if there are none. Empty string is
+             returned so that cache created by older versions of sinol-make stays valid for packages
+             which don't use them.
+    """
+    family = COMPILATION_LANG_FAMILIES.get(lang, lang)
+    files = [file for file in extra_compilation_files or []
+             if COMPILATION_LANG_FAMILIES.get(get_file_lang(file), get_file_lang(file)) == family]
+    if not extra_compilation_args and not files:
+        return ""
+
+    # Only basenames are used, so that moving the package doesn't invalidate the cache.
+    parts = []
+    # Order of arguments matters for the compiler, so they are not sorted.
+    for arg in extra_compilation_args or []:
+        if os.path.isfile(arg):
+            parts.append(f'{os.path.basename(arg)}:{util.get_file_md5(arg)}')
+        else:
+            # The argument is a compilation flag, not a file.
+            parts.append(arg)
+    # Order of files doesn't matter, but it has to be stable.
+    for file in sorted(files, key=os.path.basename):
+        if os.path.isfile(file):
+            parts.append(f'{os.path.basename(file)}:{util.get_file_md5(file)}')
+        else:
+            parts.append(f'{os.path.basename(file)}:missing')
+    return hashlib.md5('\n'.join(parts).encode('utf-8')).hexdigest()
 
 
 def get_solutions_re(task_id: str) -> re.Pattern:

--- a/src/sinol_make/structs/cache_structs.py
+++ b/src/sinol_make/structs/cache_structs.py
@@ -47,16 +47,20 @@ class CacheFile:
     compilation_flags: str
     # What sanitizers were used
     sanitizers: str
+    # Hash of extra compilation arguments and files used during compilation
+    extra_compilation_hash: str
     # Test results
     tests: Dict[str, CacheTest]
 
-    def __init__(self, md5sum="", executable_path="", compilation_flags="default", sanitizers="no", tests=None):
+    def __init__(self, md5sum="", executable_path="", compilation_flags="default", sanitizers="no",
+                 extra_compilation_hash="", tests=None):
         if tests is None:
             tests = {}
         self.md5sum = md5sum
         self.executable_path = executable_path
         self.compilation_flags = compilation_flags
         self.sanitizers = sanitizers
+        self.extra_compilation_hash = extra_compilation_hash
         self.tests = tests
 
     def to_dict(self) -> Dict:
@@ -65,6 +69,7 @@ class CacheFile:
             "executable_path": self.executable_path,
             "compilation_flags": self.compilation_flags,
             "sanitizers": self.sanitizers,
+            "extra_compilation_hash": self.extra_compilation_hash,
             "tests": {k: v.to_dict() for k, v in self.tests.items()}
         }
 
@@ -79,6 +84,9 @@ class CacheFile:
             executable_path=dict.get("executable_path", ""),
             compilation_flags=dict.get("compilation_flags", "default"),
             sanitizers=dict.get("sanitizers", 'no'),
+            # Older versions of sinol-make didn't store the hash. Empty string means that
+            # the package didn't use extra compilation arguments or files.
+            extra_compilation_hash=dict.get("extra_compilation_hash", ""),
             tests={k: CacheTest(
                 time_limit=v["time_limit"],
                 memory_limit=v["memory_limit"],

--- a/tests/commands/run/test_integration.py
+++ b/tests/commands/run/test_integration.py
@@ -706,17 +706,39 @@ def test_extra_compilation_files_change(create_package, time_tool):
         with open(file, "w") as f:
             f.write(f"{comment_character} Changed source code.\n" + source)
 
-    def test(file_to_change, lang, comment_character, extra_compilation_files=True):
-        # First run to cache test results.
+    def test_compilation_file(file_to_change, lang, comment_character):
+        # First run to compile solutions and cache test results.
         command.run(args)
 
         # Change file
         change_file(os.path.join(os.getcwd(), "prog", file_to_change), comment_character)
 
-        if extra_compilation_files:
-            cache.process_extra_compilation_files(command.config.get("extra_compilation_files", []), command.ID)
-        else:
-            cache.process_extra_execution_files(command.config.get("extra_execution_files", {}), command.ID)
+        # Changing an extra compilation file invalidates the compilation cache on its own,
+        # no command has to clean the cache up beforehand.
+        task_id = package_util.get_task_id()
+        solutions = package_util.get_solutions(task_id, None)
+        for solution in solutions:
+            solution_lang = package_util.get_file_lang(solution)
+            extra_compilation_hash = package_util.get_extra_compilation_hash(
+                solution_lang, package_util.get_extra_compilation_args(solution_lang, command.config),
+                package_util.get_extra_compilation_files(command.config))
+            compiled = cache.check_compiled(os.path.join(os.getcwd(), "prog", solution), "default", "no",
+                                            extra_compilation_hash)
+            print(file_to_change, solution)
+            if solution_lang == lang:
+                assert compiled is None
+            else:
+                # Solutions in other languages don't use the changed file.
+                assert compiled is not None
+
+    def test_execution_file(file_to_change, lang, comment_character):
+        # First run to compile solutions and cache test results.
+        command.run(args)
+
+        # Change file
+        change_file(os.path.join(os.getcwd(), "prog", file_to_change), comment_character)
+
+        cache.process_extra_execution_files(command.config.get("extra_execution_files", {}), command.ID)
         task_id = package_util.get_task_id()
         solutions = package_util.get_solutions(task_id, None)
         for solution in solutions:
@@ -726,9 +748,47 @@ def test_extra_compilation_files_change(create_package, time_tool):
                 info = cache.get_cache_file(solution)
                 assert info == CacheFile()
 
-    test("liblib.cpp", "cpp", "//")
-    test("liblib.h", "cpp", "//")
-    test("liblib.py", "py", "#", False)
+    test_compilation_file("liblib.cpp", "cpp", "//")
+    test_compilation_file("liblib.h", "cpp", "//")
+    test_execution_file("liblib.py", "py", "#")
+
+
+@pytest.mark.parametrize("create_package", [get_library_package_path()], indirect=True)
+def test_extra_compilation_args_change(create_package, time_tool):
+    """
+    Test if after changing extra compilation arguments solutions are compiled again.
+    """
+    package_path = create_package
+    create_ins_outs(package_path)
+    parser = configure_parsers()
+    args = parser.parse_args(["run", "--time-tool", time_tool])
+    command = Command()
+    command.run(args)
+
+    task_id = package_util.get_task_id()
+    solutions = package_util.get_solutions(task_id, None)
+
+    def check_compiled(config):
+        compiled = {}
+        for solution in solutions:
+            lang = package_util.get_file_lang(solution)
+            extra_compilation_hash = package_util.get_extra_compilation_hash(
+                lang, package_util.get_extra_compilation_args(lang, config),
+                package_util.get_extra_compilation_files(config))
+            compiled[solution] = cache.check_compiled(os.path.join(os.getcwd(), "prog", solution), "default", "no",
+                                                      extra_compilation_hash) is not None
+        return compiled
+
+    assert all(check_compiled(command.config).values())
+
+    config = package_util.get_config()
+    config["extra_compilation_args"]["cpp"].append("-DSINOL_MAKE_TEST")
+    util.save_config(config)
+
+    compiled = check_compiled(package_util.get_config())
+    for solution, is_compiled in compiled.items():
+        # Only C++ solutions use the changed arguments.
+        assert is_compiled == (package_util.get_file_lang(solution) != "cpp")
 
 
 @pytest.mark.parametrize("create_package", [get_simple_package_path()], indirect=True)

--- a/tests/helpers/test_cache.py
+++ b/tests/helpers/test_cache.py
@@ -1,7 +1,10 @@
 import os
 import tempfile
 
-from sinol_make.helpers import compile, paths
+import yaml
+
+from sinol_make import util
+from sinol_make.helpers import compile, package_util, paths
 from sinol_make.helpers import cache
 from sinol_make.structs.cache_structs import CacheFile, CacheTest
 from sinol_make.structs.status_structs import ExecutionResult, Status
@@ -87,26 +90,6 @@ def test_cache():
                             clear_cache=True)
         assert cache.get_cache_file("abc.cpp").tests == {}
 
-        # Test that cache is cleared when extra compilation files change
-        cache_file.save("abc.cpp")
-        os.mkdir("prog")
-        with open("prog/abclib.cpp", "w") as f:
-            f.write("int main() { return 0; }")
-
-        cache.process_extra_compilation_files(["abclib.cpp"], "abc")
-        assert cache.get_cache_file("/some/very/long/path/abc.cpp") == CacheFile()
-        assert cache.get_cache_file("abclib.cpp") != CacheFile()
-
-        cache_file.save("abc.cpp")
-        cache_file.save("abc.py")
-        with open("prog/abclib.cpp", "w") as f:
-            f.write("/* Changed file */ int main() { return 0; }")
-        cache.process_extra_compilation_files(["abclib.cpp"], "abc")
-        assert not os.path.exists(paths.get_cache_path("md5sums", "abc.cpp"))
-        assert os.path.exists(paths.get_cache_path("md5sums", "abc.py"))
-        assert cache.get_cache_file("abc.py") == cache_file
-        assert cache.get_cache_file("abc.cpp") == CacheFile()
-
         # Test if after changing contest type all cached test results are removed
         cache_file.save("abc.cpp")
         cache_file.save("abc.py")
@@ -118,3 +101,100 @@ def test_cache():
         cache.remove_results_if_contest_type_changed("oi")
         assert cache.get_cache_file("abc.py").tests == {}
         assert cache.get_cache_file("abc.cpp").tests == {}
+
+
+def test_old_cache_file():
+    """
+    Test if cache files saved by versions of sinol-make which didn't store
+    the extra compilation hash are still valid.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        cache.create_cache_dirs()
+        program = os.path.join(tmpdir, 'program.cpp')
+        open(program, 'w').write('int main() { return 0; }')
+        exe_path = os.path.join(tmpdir, 'program')
+        open(exe_path, 'w').write('')
+
+        cache_file = CacheFile(md5sum=util.get_file_md5(program), executable_path=exe_path)
+        contents = cache_file.to_dict()
+        del contents["extra_compilation_hash"]
+        with open(paths.get_cache_path("md5sums", "program.cpp"), "w") as f:
+            yaml.dump(contents, f)
+
+        assert cache.get_cache_file(program) == cache_file
+        assert cache.check_compiled(program, "default", "no") == exe_path
+
+
+def test_extra_compilation_files_caching():
+    """
+    Test if changing an extra compilation file invalidates the compilation cache.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        cache.create_cache_dirs()
+        os.mkdir("prog")
+        library = os.path.join(tmpdir, "prog", "abclib.cpp")
+        open(library, 'w').write('int lib() { return 0; }\n')
+        program = os.path.join(tmpdir, "prog", "abc.cpp")
+        open(program, 'w').write('int lib();\nint main() { return lib(); }\n')
+        output = os.path.join(tmpdir, "abc.e")
+
+        def compile_program():
+            return compile.compile(program, output, compile_log=None, extra_compilation_args=[library],
+                                   extra_compilation_files=[library])
+
+        def get_hash():
+            return package_util.get_extra_compilation_hash("cpp", [library], [library])
+
+        assert compile_program()
+        assert cache.check_compiled(program, "default", "no", get_hash()) is not None
+        # The executable can't be used when the library isn't compiled in.
+        assert cache.check_compiled(program, "default", "no") is None
+        # The library is copied next to the executable, so that it's always up to date.
+        assert util.get_file_md5(os.path.join(tmpdir, "abclib.cpp")) == util.get_file_md5(library)
+
+        previous_hash = get_hash()
+        open(library, 'w').write('int lib() { return 0; } // Changed library.\n')
+        assert get_hash() != previous_hash
+        assert cache.check_compiled(program, "default", "no", get_hash()) is None
+
+        assert compile_program()
+        assert cache.check_compiled(program, "default", "no", get_hash()) is not None
+        assert util.get_file_md5(os.path.join(tmpdir, "abclib.cpp")) == util.get_file_md5(library)
+
+        # Extra compilation files in other languages don't affect compilation.
+        assert package_util.get_extra_compilation_hash("py", [], [library]) == ""
+        assert package_util.get_extra_compilation_hash("cpp", [], [library]) != ""
+        # Header files affect compilation of C and C++ files.
+        header = os.path.join(tmpdir, "prog", "abclib.h")
+        open(header, 'w').write('int lib();\n')
+        assert package_util.get_extra_compilation_hash("cpp", [], [header]) != ""
+        assert package_util.get_extra_compilation_hash("c", [], [header]) != ""
+
+
+def test_extra_compilation_args_caching():
+    """
+    Test if changing extra compilation arguments invalidates the compilation cache.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        cache.create_cache_dirs()
+        program = os.path.join(tmpdir, 'program.cpp')
+        open(program, 'w').write('int main() { return 0; }')
+        output = os.path.join(tmpdir, 'program')
+
+        assert compile.compile(program, output, compile_log=None)
+        assert cache.check_compiled(program, "default", "no") is not None
+
+        # Adding a compilation flag invalidates the cache.
+        flag_hash = package_util.get_extra_compilation_hash("cpp", ["-DFOO"], [])
+        assert flag_hash != ""
+        assert cache.check_compiled(program, "default", "no", flag_hash) is None
+
+        assert compile.compile(program, output, compile_log=None, extra_compilation_args=["-DFOO"])
+        assert cache.check_compiled(program, "default", "no", flag_hash) is not None
+        # Removing or changing the flag invalidates the cache again.
+        assert cache.check_compiled(program, "default", "no") is None
+        assert cache.check_compiled(
+            program, "default", "no", package_util.get_extra_compilation_hash("cpp", ["-DBAR"], [])) is None


### PR DESCRIPTION
Fixes #327.

Until now `check_compiled` only compared the md5sum of the compiled file,
the compilation flags group and the sanitizers, so nothing that comes from
`extra_compilation_args` and `extra_compilation_files` was part of the cache
key. Changes to a library were noticed only by `process_extra_compilation_files`,
which was called just by the `run` command and removed cache files only for
programs matching the solution regex. Because of that `gen`, `outgen`, `ingen`,
`inwer` and `chkwer` reused stale executables after a library was changed, and
changing `extra_compilation_args` (for example adding a compiler flag) never
invalidated anything.

Instead of removing cache files up front, the identity of the extras is now
part of the cache entry. `package_util.get_extra_compilation_hash` hashes the
extra compilation arguments together with the contents of the extra compilation
files of the compiled language, and `compile` stores and compares it, so every
command and every compiled file is handled the same way. The hash is empty when
a package doesn't use extras, so existing cache stays valid.

The same hash is used by `check_correct_solution`, so changing a library or a
compilation flag also regenerates output files.

Along the way:
- the duplicated resolution of extras in `run` and `compile_file` moved to
  `package_util.get_extra_compilation_args` / `get_extra_compilation_files`,
- extra compilation files are copied to the executables directory even when the
  executable is cached, so the directory doesn't show stale sources,
- `process_extra_compilation_files` is gone, `process_extra_execution_files`
  stays, as execution files don't take part in compilation.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Nm4cipNhmZZYkBSQU74juZ