### PR TITLE
Fix swapped file order when running oicompare

### DIFF
--- a/src/sinol_make/task_type/__init__.py
+++ b/src/sinol_make/task_type/__init__.py
@@ -164,7 +164,8 @@ class BaseTaskType(RegisteredSubclassesBase):
 
     def _run_oicompare(self, output_file_path, answer_file_path) -> Tuple[bool, Fraction, str, str]:
         path = oicompare.get_path()
-        proc = subprocess.Popen([path, output_file_path, answer_file_path, 'english_abbreviated'],
+        # oicompare expects the correct answer as the first argument and the contestant's output as the second one.
+        proc = subprocess.Popen([path, answer_file_path, output_file_path, 'english_abbreviated'],
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         proc.wait()
         output, stderr = proc.communicate()

--- a/tests/test_task_type.py
+++ b/tests/test_task_type.py
@@ -1,0 +1,34 @@
+import os
+import pytest
+
+from sinol_make.helpers import oicompare
+from sinol_make.task_type import BaseTaskType
+from sinol_make.task_type.normal import NormalTaskType
+
+
+@pytest.mark.skipif(not oicompare.check_installed(), reason="oicompare is not installed")
+def test_oicompare_arguments_order(tmpdir):
+    """
+    Tests if the contestant's output and the correct answer are passed to oicompare in the right order.
+    """
+    output_file = os.path.join(tmpdir, "out.out")
+    answer_file = os.path.join(tmpdir, "ans.out")
+    with open(output_file, "w") as f:
+        f.write("contestant\n")
+    with open(answer_file, "w") as f:
+        f.write("correct\n")
+
+    # __init__ requires a package, which isn't needed for running oicompare.
+    task_type = BaseTaskType.__new__(NormalTaskType)
+    correct, points, comment, _ = task_type._run_oicompare(output_file, answer_file)
+    assert not correct
+    assert points == 0
+    assert 'expected "correct"' in comment
+    assert 'got "contestant"' in comment
+
+    with open(output_file, "w") as f:
+        f.write("correct\n")
+    correct, points, comment, _ = task_type._run_oicompare(output_file, answer_file)
+    assert correct
+    assert points == 100
+    assert comment == ""


### PR DESCRIPTION
oicompare is called as `oicompare <expected> <received>`, but sinol-make
passed the contestant's output first and the correct answer second. As a
result, every wrong answer comment was reversed, e.g. it reported
`expected "<contestant output>", got "<correct answer>"`.

Fixes #303

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UaeGd7auquKGb3B9HCwMX4